### PR TITLE
Add Module Filtering

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CdCommand.java
@@ -6,6 +6,9 @@ import seedu.address.model.person.PartOfModulePredicate;
 
 import static java.util.Objects.requireNonNull;
 
+// TODO: Consider updating UI to show the current selected module
+// TODO: Update UG/DG
+
 /**
  * Changes the selected module.
  */

--- a/src/main/java/seedu/address/logic/commands/CdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CdCommand.java
@@ -1,10 +1,10 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.PartOfModulePredicate;
-
-import static java.util.Objects.requireNonNull;
 
 // TODO: Consider updating UI to show the current selected module
 // TODO: Update UG/DG

--- a/src/main/java/seedu/address/logic/commands/CdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CdCommand.java
@@ -14,7 +14,7 @@ public class CdCommand extends Command {
     public static final String COMMAND_WORD = "cd";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Changes the currently selected module.\n"
+            + ": Changes the currently selected module. Use '*' to show all modules.\n"
             + "Parameters: NAME\n"
             + "Example: " + COMMAND_WORD + " CS1101S";
 

--- a/src/main/java/seedu/address/logic/commands/CdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CdCommand.java
@@ -1,0 +1,43 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.PartOfModulePredicate;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Changes the selected module.
+ */
+public class CdCommand extends Command {
+
+    public static final String COMMAND_WORD = "cd";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Changes the currently selected module.\n"
+            + "Parameters: NAME\n"
+            + "Example: " + COMMAND_WORD + " CS1101S";
+
+    private final PartOfModulePredicate predicate;
+
+    public CdCommand(PartOfModulePredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.setModuleFilter(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof CdCommand // instanceof handles nulls
+                && predicate.equals(((CdCommand) other).predicate)); // state check
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -82,7 +82,7 @@ public class EditCommand extends Command {
         }
 
         model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -28,7 +28,7 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        model.setSearchFilter(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
     }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -18,7 +18,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -7,6 +7,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.CdCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
@@ -58,6 +59,9 @@ public class AddressBookParser {
 
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
+        case CdCommand.COMMAND_WORD:
+            return new CdCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();

--- a/src/main/java/seedu/address/logic/parser/CdCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CdCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.model.person.PartOfModulePredicate.PREDICATE_SHOW_ALL_MODULES;
 
 import seedu.address.logic.commands.CdCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -21,6 +22,10 @@ public class CdCommandParser implements Parser<CdCommand> {
         if (trimmedArgs.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, CdCommand.MESSAGE_USAGE));
+        }
+
+        if (trimmedArgs.equalsIgnoreCase("*")) {
+            return new CdCommand(PREDICATE_SHOW_ALL_MODULES);
         }
 
         return new CdCommand(new PartOfModulePredicate(trimmedArgs));

--- a/src/main/java/seedu/address/logic/parser/CdCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CdCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.CdCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.PartOfModulePredicate;
+
+/**
+ * Parses input arguments and creates a new CdCommand object
+ */
+public class CdCommandParser implements Parser<CdCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CdCommand
+     * and returns a CdCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public CdCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, CdCommand.MESSAGE_USAGE));
+        }
+
+        return new CdCommand(new PartOfModulePredicate(trimmedArgs));
+    }
+
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -80,8 +80,14 @@ public interface Model {
     ObservableList<Person> getFilteredPersonList();
 
     /**
-     * Updates the filter of the filtered person list to filter by the given {@code predicate}.
+     * Updates the module filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredPersonList(Predicate<Person> predicate);
+    void setModuleFilter(Predicate<Person> predicate);
+
+    /**
+     * Updates the search filter of the filtered person list to filter by the given {@code predicate}.
+     * @throws NullPointerException if {@code predicate} is null.
+     */
+    void setSearchFilter(Predicate<Person> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -127,10 +127,10 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setModuleFilter(Predicate<Person> predicate) {
-        requireNonNull(predicate);
-        this.selectedModulePredicate = predicate;
-        filteredPersons.setPredicate(predicate);
+    public void setModuleFilter(Predicate<Person> modulePredicate) {
+        requireNonNull(modulePredicate);
+        this.selectedModulePredicate = modulePredicate;
+        filteredPersons.setPredicate(modulePredicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
+import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
@@ -22,6 +23,8 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+
+    private Predicate<Person> selectedModulePredicate;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -102,7 +105,7 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -124,9 +127,18 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredPersonList(Predicate<Person> predicate) {
+    public void setModuleFilter(Predicate<Person> predicate) {
         requireNonNull(predicate);
+        this.selectedModulePredicate = predicate;
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void setSearchFilter(Predicate<Person> searchPredicate) {
+        requireNonNull(searchPredicate);
+        Predicate<Person> modulePredicate =
+                Optional.ofNullable(this.selectedModulePredicate).orElse(PREDICATE_SHOW_ALL_PERSONS);
+        filteredPersons.setPredicate(modulePredicate.and(searchPredicate));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/PartOfModulePredicate.java
+++ b/src/main/java/seedu/address/model/person/PartOfModulePredicate.java
@@ -1,0 +1,30 @@
+package seedu.address.model.person;
+
+// TODO: Use a `Module` class instead of String
+
+import seedu.address.model.tag.Tag;
+
+import java.util.function.Predicate;
+
+/**
+ * Tests if a {@code Person} is part of a module.
+ */
+public class PartOfModulePredicate implements Predicate<Person> {
+    private final Tag moduleTag;
+
+    public PartOfModulePredicate(String module) {
+        this.moduleTag = new Tag(module);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return person.getTags().contains(moduleTag);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PartOfModulePredicate // instanceof handles nulls
+                && moduleTag.equals(((PartOfModulePredicate) other).moduleTag)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/person/PartOfModulePredicate.java
+++ b/src/main/java/seedu/address/model/person/PartOfModulePredicate.java
@@ -2,15 +2,15 @@ package seedu.address.model.person;
 
 // TODO: Use a `Module` class instead of String
 
-import seedu.address.model.tag.Tag;
-
 import java.util.function.Predicate;
+
+import seedu.address.model.tag.Tag;
 
 /**
  * Tests if a {@code Person} is part of a module.
  */
 public class PartOfModulePredicate implements Predicate<Person> {
-    public static final PartOfModulePredicate PREDICATE_SHOW_ALL_MODULES  = new PartOfModulePredicate("unused") {
+    public static final PartOfModulePredicate PREDICATE_SHOW_ALL_MODULES = new PartOfModulePredicate("unused") {
         public boolean test(Person person) {
             return true;
         }

--- a/src/main/java/seedu/address/model/person/PartOfModulePredicate.java
+++ b/src/main/java/seedu/address/model/person/PartOfModulePredicate.java
@@ -10,6 +10,12 @@ import java.util.function.Predicate;
  * Tests if a {@code Person} is part of a module.
  */
 public class PartOfModulePredicate implements Predicate<Person> {
+    public static final PartOfModulePredicate PREDICATE_SHOW_ALL_MODULES  = new PartOfModulePredicate("unused") {
+        public boolean test(Person person) {
+            return true;
+        }
+    };
+
     private final Tag moduleTag;
 
     public PartOfModulePredicate(String module) {

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -144,7 +144,12 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
+        public void setSearchFilter(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setModuleFilter(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -120,7 +120,7 @@ public class CommandTestUtil {
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.setSearchFilter(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -102,7 +102,7 @@ public class DeleteCommandTest {
      * Updates {@code model}'s filtered list to show no one.
      */
     private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
+        model.setSearchFilter(p -> false);
 
         assertTrue(model.getFilteredPersonList().isEmpty());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -59,7 +59,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.setSearchFilter(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
     }
@@ -69,7 +69,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.setSearchFilter(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -118,11 +118,11 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.setSearchFilter(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
-        modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        modelManager.setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();


### PR DESCRIPTION
Related to https://github.com/AY2122S1-CS2103-W14-3/tp/issues/71.

Changes:
- We distinguish the predicates used for the filtered list.
  - `setModuleFilter` - Sets the predicate used to show students from the same module. This predicate is applied to every subsequent search predicate as well.
  - `setSearchFilter` - Sets the predicate used to show the results of `FindCommand`. This predicate is combined with the module predicate to show all students from the selected module AND matching the search predicate.
- Added `CdCommand` - Changes the selected module
- Added `PartOfModulePredicate` - Checks if a person is part of a module. Currently uses tags, but should change it when we actually implement modules.

Todos:
- Add UI element (can be as simple as text label) to show which module is selected
- Update UG and DG with new command
- Update implementation of `PartOfModulePredicate` to use actual implementation of modules.
- Add tests to improve coverage