### PR TITLE
Configure Info to be optional

### DIFF
--- a/src/main/java/seedu/edrecord/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/edrecord/logic/parser/AddCommandParser.java
@@ -40,7 +40,8 @@ public class AddCommandParser implements Parser<AddCommand> {
                         PREFIX_MODULE, PREFIX_GROUP, PREFIX_TAG);
 
         if (!arePrefixesPresent(
-                argMultimap, PREFIX_NAME, PREFIX_INFO, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_MODULE, PREFIX_GROUP)
+                argMultimap, PREFIX_NAME, PREFIX_INFO, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_MODULE,
+            PREFIX_GROUP, PREFIX_TAG)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
         }
@@ -54,7 +55,6 @@ public class AddCommandParser implements Parser<AddCommand> {
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
         Person person = new Person(name, phone, email, info, module, group, tagList);
-
         return new AddCommand(person);
     }
 
@@ -63,7 +63,12 @@ public class AddCommandParser implements Parser<AddCommand> {
      * {@code ArgumentMultimap}.
      */
     public static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+        return Stream.of(prefixes).allMatch(prefix -> {
+            boolean multiMapContainsPrefix = argumentMultimap.getValue(prefix).isPresent();
+            if (!multiMapContainsPrefix) {
+                return prefix.getPrefixIsOptional() == PrefixIsOptional.YES;
+            }
+            return multiMapContainsPrefix;
+        });
     }
-
 }

--- a/src/main/java/seedu/edrecord/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/edrecord/logic/parser/ArgumentMultimap.java
@@ -33,10 +33,11 @@ public class ArgumentMultimap {
 
     /**
      * Returns the last value of {@code prefix}.
+     * If the value is empty, return an empty string.
      */
     public Optional<String> getValue(Prefix prefix) {
         List<String> values = getAllValues(prefix);
-        return values.isEmpty() ? Optional.empty() : Optional.of(values.get(values.size() - 1));
+        return values.isEmpty() ? Optional.of("") : Optional.of(values.get(values.size() - 1));
     }
 
     /**

--- a/src/main/java/seedu/edrecord/logic/parser/ArgumentTokenizer.java
+++ b/src/main/java/seedu/edrecord/logic/parser/ArgumentTokenizer.java
@@ -1,7 +1,6 @@
 package seedu.edrecord.logic.parser;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +28,24 @@ public class ArgumentTokenizer {
     }
 
     /**
+     * Returns a new list of prefixes after removing all prefixes that are both missing and optional.
+     *
+     * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
+     * @param prefixes Prefixes to tokenize the arguments string with
+     * @return A new list of prefixes without the missing optional prefixes.
+     */
+    public static List<Prefix> removeMissingOptionalPrefixes(String argsString, Prefix... prefixes) {
+        List<Prefix> prefixesWithoutMissingOptional = new ArrayList<>();
+        for (Prefix prefix : prefixes) {
+            if (prefix.getPrefixIsOptional() == PrefixIsOptional.YES && !argsString.contains(prefix.getPrefix())) {
+                continue;
+            }
+            prefixesWithoutMissingOptional.add(prefix);
+        }
+        return prefixesWithoutMissingOptional;
+    }
+
+    /**
      * Finds all zero-based prefix positions in the given arguments string.
      *
      * @param argsString Arguments string of the form: {@code preamble <prefix>value <prefix>value ...}
@@ -36,7 +53,8 @@ public class ArgumentTokenizer {
      * @return           List of zero-based prefix positions in the given arguments string
      */
     private static List<PrefixPosition> findAllPrefixPositions(String argsString, Prefix... prefixes) {
-        return Arrays.stream(prefixes)
+        List<Prefix> prefixesWithoutMissingOptional = removeMissingOptionalPrefixes(argsString, prefixes);
+        return prefixesWithoutMissingOptional.stream()
                 .flatMap(prefix -> findPrefixPositions(argsString, prefix).stream())
                 .collect(Collectors.toList());
     }

--- a/src/main/java/seedu/edrecord/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/edrecord/logic/parser/CliSyntax.java
@@ -9,7 +9,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_NAME = new Prefix("n/");
     public static final Prefix PREFIX_PHONE = new Prefix("p/");
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
-    public static final Prefix PREFIX_INFO = new Prefix("i/");
+    public static final Prefix PREFIX_INFO = new Prefix("i/", PrefixIsOptional.YES);
     public static final Prefix PREFIX_MODULE = new Prefix("m/");
     public static final Prefix PREFIX_GROUP = new Prefix("c/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");

--- a/src/main/java/seedu/edrecord/logic/parser/Prefix.java
+++ b/src/main/java/seedu/edrecord/logic/parser/Prefix.java
@@ -6,9 +6,28 @@ package seedu.edrecord.logic.parser;
  */
 public class Prefix {
     private final String prefix;
+    private final PrefixIsOptional isOptional;
 
+    /**
+     * Constructs an {@code Prefix} that is not optional by default.
+     * @param prefix The prefix's value.
+     */
     public Prefix(String prefix) {
         this.prefix = prefix;
+        this.isOptional = PrefixIsOptional.NO;
+    }
+    /**
+     * Constructs an {@code Prefix} that specifies if it's optional.
+     * @param prefix The prefix's value.
+     * @param isOptional An enum to indicate if prefix is optional.
+     */
+    public Prefix(String prefix, PrefixIsOptional isOptional) {
+        this.prefix = prefix;
+        this.isOptional = isOptional;
+    }
+
+    public PrefixIsOptional getPrefixIsOptional() {
+        return this.isOptional;
     }
 
     public String getPrefix() {

--- a/src/main/java/seedu/edrecord/logic/parser/PrefixIsOptional.java
+++ b/src/main/java/seedu/edrecord/logic/parser/PrefixIsOptional.java
@@ -1,0 +1,5 @@
+package seedu.edrecord.logic.parser;
+
+public enum PrefixIsOptional {
+    YES, NO
+}

--- a/src/main/java/seedu/edrecord/model/person/Info.java
+++ b/src/main/java/seedu/edrecord/model/person/Info.java
@@ -1,40 +1,35 @@
 package seedu.edrecord.model.person;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.edrecord.commons.util.AppUtil.checkArgument;
 
 /**
  * Represents a Person's info in edrecord.
  * Guarantees: immutable; is valid as declared in {@link #isValidInfo(String)}
  */
 public class Info {
-
-    public static final String MESSAGE_CONSTRAINTS = "Info can take any values, and it should not be blank";
-
-    /*
-     * The first character of info must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[^\\s].*";
+    public static final String MESSAGE_CONSTRAINTS = "Info can take any non-null values, and it should not be blank";
 
     public final String value;
 
     /**
      * Constructs an {@code Info}.
      *
-     * @param info A valid info.
+     * @param info An info. Info can be left blank.
      */
     public Info(String info) {
         requireNonNull(info);
-        checkArgument(isValidInfo(info), MESSAGE_CONSTRAINTS);
         value = info;
     }
 
     /**
      * Returns true if a given string is a valid email.
+     * An info can be empty string, but cannot only be whitespace or null.
      */
     public static boolean isValidInfo(String test) {
-        return test.matches(VALIDATION_REGEX);
+        if (test != null && test.isBlank()) {
+            return test.isEmpty();
+        }
+        return test != null;
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/person/Person.java
+++ b/src/main/java/seedu/edrecord/model/person/Person.java
@@ -125,10 +125,12 @@ public class Person {
                 .append("; Phone: ")
                 .append(getPhone())
                 .append("; Email: ")
-                .append(getEmail())
-                .append("; Info: ")
-                .append(getInfo())
-                .append("; Module: ")
+                .append(getEmail());
+        if (!getInfo().value.isBlank()) {
+            builder.append("; Info: ")
+                .append(getInfo());
+        }
+        builder.append("; Module: ")
                 .append(getModule())
                 .append("; Group: ")
                 .append(getGroup());

--- a/src/main/java/seedu/edrecord/ui/PersonCard.java
+++ b/src/main/java/seedu/edrecord/ui/PersonCard.java
@@ -55,6 +55,10 @@ public class PersonCard extends UiPart<Region> {
         name.setText(person.getName().name);
         phone.setText(person.getPhone().value);
         info.setText(person.getInfo().value);
+        if (person.getInfo().value.isBlank()) {
+            info.setVisible(false);
+            info.managedProperty().bind(info.visibleProperty());
+        }
         email.setText(person.getEmail().value);
         module.setText(person.getModule().getCode());
         group.setText(person.getGroup().getCode());


### PR DESCRIPTION
Closes #87 
Allow the Info to not be specified when creating a new person.

I've added a field to the prefixes, to allow any of the fields to be optional. I've also made relevant changes to the FXML and success messages, such that they will not show the info field if info field is not specified. The default value of the non-specified info field is hardcoded as an empty string.

![image](https://user-images.githubusercontent.com/10182564/137877670-08421b16-8578-47bd-b163-56a957a3e493.png)
