### PR TITLE
Fix bug for allowing non-existent class when adding person 

### DIFF
--- a/src/main/java/seedu/edrecord/AppParameters.java
+++ b/src/main/java/seedu/edrecord/AppParameters.java
@@ -34,6 +34,7 @@ public class AppParameters {
         Map<String, String> namedParameters = parameters.getNamed();
 
         String configPathParameter = namedParameters.get("config");
+        System.out.println(String.format("%s %s", configPathParameter, FileUtil.isValidPath(configPathParameter)));
         if (configPathParameter != null && !FileUtil.isValidPath(configPathParameter)) {
             logger.warning("Invalid config path " + configPathParameter + ". Using default config path.");
             configPathParameter = null;

--- a/src/main/java/seedu/edrecord/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/AddCommand.java
@@ -11,6 +11,7 @@ import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.edrecord.logic.commands.exceptions.CommandException;
 import seedu.edrecord.model.Model;
+import seedu.edrecord.model.group.Group;
 import seedu.edrecord.model.module.Module;
 import seedu.edrecord.model.person.Person;
 
@@ -62,6 +63,11 @@ public class AddCommand extends Command {
 
         if (!model.hasModule(toAdd.getModule())) {
             throw new CommandException(Module.MESSAGE_DOES_NOT_EXIST);
+        }
+
+        Module mod = toAdd.getModule();
+        if (!mod.hasGroup(toAdd.getGroup())) {
+            throw new CommandException(Group.MESSAGE_DOES_NOT_EXIST);
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/edrecord/logic/commands/MakeGroupCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/MakeGroupCommand.java
@@ -37,6 +37,7 @@ public class MakeGroupCommand extends Command {
      */
     public MakeGroupCommand(Group group, Module mod) {
         requireAllNonNull(group);
+        requireAllNonNull(mod);
 
         this.group = group;
         this.module = mod;

--- a/src/main/java/seedu/edrecord/model/group/GroupSystem.java
+++ b/src/main/java/seedu/edrecord/model/group/GroupSystem.java
@@ -100,8 +100,7 @@ public class GroupSystem implements ReadOnlyGroupSystem {
 
     @Override
     public String toString() {
-        return groups.asUnmodifiableObservableList().size() + " classes";
-        // TODO: refine later
+        return groups.toString();
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/group/UniqueGroupList.java
+++ b/src/main/java/seedu/edrecord/model/group/UniqueGroupList.java
@@ -3,6 +3,7 @@ package seedu.edrecord.model.group;
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -122,5 +123,14 @@ public class UniqueGroupList implements Iterable<Group> {
             }
         }
         return true;
+    }
+
+    @Override
+    public String toString() {
+        List<Group> groups = new ArrayList<>();
+        for (Group group : internalList) {
+            groups.add(group);
+        }
+        return groups.toString();
     }
 }

--- a/src/main/java/seedu/edrecord/model/module/ModuleSystem.java
+++ b/src/main/java/seedu/edrecord/model/module/ModuleSystem.java
@@ -109,8 +109,7 @@ public class ModuleSystem implements ReadOnlyModuleSystem {
 
     @Override
     public String toString() {
-        return modules.asUnmodifiableObservableList().size() + " modules";
-        // TODO: refine later
+        return modules.toString();
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/module/UniqueModuleList.java
+++ b/src/main/java/seedu/edrecord/model/module/UniqueModuleList.java
@@ -3,6 +3,7 @@ package seedu.edrecord.model.module;
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -136,5 +137,14 @@ public class UniqueModuleList implements Iterable<Module> {
             }
         }
         return true;
+    }
+
+    @Override
+    public String toString() {
+        List<Module> modules = new ArrayList<>();
+        for (Module module : internalList) {
+            modules.add(module);
+        }
+        return modules.toString();
     }
 }

--- a/src/test/java/seedu/edrecord/logic/commands/ListModulesCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/ListModulesCommandTest.java
@@ -35,7 +35,6 @@ public class ListModulesCommandTest {
 
         String moduleList = String.join(ListModulesCommand.MODULE_LIST_DELIM, moduleStringList);
         String expectedOutput = String.format(ListModulesCommand.MESSAGE_SUCCESS, moduleList);
-        System.out.println(expectedOutput);
 
         CommandResult expectedCommandResult = new CommandResult(expectedOutput);
         assertCommandSuccess(new ListModulesCommand(), model, expectedCommandResult, expectedModel);

--- a/src/test/java/seedu/edrecord/logic/commands/MakeGroupCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/MakeGroupCommandTest.java
@@ -1,0 +1,69 @@
+package seedu.edrecord.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.edrecord.logic.commands.exceptions.CommandException;
+import seedu.edrecord.model.EdRecord;
+import seedu.edrecord.model.ModelManager;
+import seedu.edrecord.model.UserPrefs;
+import seedu.edrecord.model.group.Group;
+import seedu.edrecord.model.module.Module;
+import seedu.edrecord.testutil.TypicalGroups;
+import seedu.edrecord.testutil.TypicalModules;
+
+public class MakeGroupCommandTest {
+    @Test
+    public void constructor_nullGroupAndModule_throwsNullPointerException() {
+        Group validGroup = TypicalGroups.T03;
+        Module validModule = TypicalModules.CS2103;
+        assertThrows(NullPointerException.class, () -> new MakeGroupCommand(validGroup, null));
+        assertThrows(NullPointerException.class, () -> new MakeGroupCommand(null, validModule));
+    }
+
+    @Test
+    public void execute_moduleDontExist_unsuccessful() {
+        ModelManager expectedModel = new ModelManager(new EdRecord(),
+            TypicalModules.getTypicalModuleSystem(), new UserPrefs());
+        Group validGroup = TypicalGroups.T03;
+        Module moduleNotInModuleSystem = TypicalModules.CS1111;
+        assertThrows(CommandException.class, () -> new MakeGroupCommand(validGroup, moduleNotInModuleSystem)
+            .execute(expectedModel));
+
+    }
+
+    @Test
+    public void execute_groupAlreadyExists_unsuccessful() {
+        ModelManager expectedModel = new ModelManager(new EdRecord(), TypicalModules.getTypicalModuleSystem(),
+            new UserPrefs());
+        Module validModule = TypicalModules.CS2103;
+        Group groupThatAlreadyExistsInModule = TypicalGroups.T03;
+        assertThrows(CommandException.class, () -> new MakeGroupCommand(groupThatAlreadyExistsInModule, validModule)
+            .execute(expectedModel));
+    }
+
+    @Test
+    public void execute_groupAddedToModule_makeGroupSuccessful() throws Exception {
+        ModelManager expectedModel = new ModelManager(new EdRecord(), TypicalModules.getTypicalModuleSystem(),
+            new UserPrefs());
+        Module validModule = TypicalModules.CS2103;
+        Group groupThatDoesNotExist = TypicalGroups.T10;
+        assertEquals(String.format(MakeGroupCommand.MESSAGE_SUCCESS, groupThatDoesNotExist, validModule),
+            new MakeGroupCommand(groupThatDoesNotExist, validModule).execute(expectedModel).getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_groupsAddedToDifferentModule_makeDifferentGroupsSuccessful() throws Exception {
+        ModelManager expectedModel = new ModelManager(new EdRecord(), TypicalModules.getTypicalModuleSystem(),
+            new UserPrefs());
+        Module validModule1 = TypicalModules.CS2103;
+        Module validModule2 = TypicalModules.CS2103T;
+        Group groupThatDoesNotExist = TypicalGroups.T12;
+        assertEquals(String.format(MakeGroupCommand.MESSAGE_SUCCESS, groupThatDoesNotExist, validModule1),
+            new MakeGroupCommand(groupThatDoesNotExist, validModule1).execute(expectedModel).getFeedbackToUser());
+        assertEquals(String.format(MakeGroupCommand.MESSAGE_SUCCESS, groupThatDoesNotExist, validModule2),
+            new MakeGroupCommand(groupThatDoesNotExist, validModule2).execute(expectedModel).getFeedbackToUser());
+    }
+}

--- a/src/test/java/seedu/edrecord/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/edrecord/testutil/TypicalGroups.java
@@ -14,6 +14,8 @@ public class TypicalGroups {
 
     public static final Group T03 = new Group("T03");
     public static final Group T07 = new Group("T07");
+    public static final Group T10 = new Group("T10");
+    public static final Group T12 = new Group("T12");
 
     private TypicalGroups() {} // prevents instantiation
 

--- a/src/test/java/seedu/edrecord/testutil/TypicalModules.java
+++ b/src/test/java/seedu/edrecord/testutil/TypicalModules.java
@@ -17,6 +17,7 @@ public class TypicalModules {
     public static final Module CS2103 = new Module("CS2103", getTypicalGroupSystem());
     public static final Module CS2103T = new Module("CS2103T", getTypicalGroupSystem());
     public static final Module CS3230 = new Module("CS3230", getTypicalGroupSystem());
+    public static final Module CS1111 = new Module("CS1111");
 
     private TypicalModules() {} // prevents instantiation
 


### PR DESCRIPTION
Fixes #100 

Fixes the bug where adding a person with a non-existent class is possible. Added tests for MakeGroupCommand.

Sample test case to replicate the problem:

    add n/Betsy Crowe p/1234567 e/betsycrowe@example.com m/CS2103 c/W-14-3 i/telegram @betyoass t/strong
    (W-14-3 is not held by the Module, but the Person has the class)
    add n/Bob p/1234567 e/betsycrowe@example.com m/CS2103 c/W-3 i/telegram @betyoass t/strong
    edit c/W-14-3

    Error Message: Class with that code has yet to be created.

