### PR TITLE
Enable assertions for Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,10 @@ checkstyle {
     toolVersion = '8.29'
 }
 
+run {
+    enableAssertions = true
+}
+
 test {
     useJUnitPlatform()
     finalizedBy jacocoTestReport


### PR DESCRIPTION
Enable assertions for the run task, as part of Week 10's tP requirements. 