### PR TITLE
Fix mismatch between status and score

### DIFF
--- a/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
@@ -16,6 +16,7 @@ import seedu.edrecord.logic.commands.exceptions.CommandException;
 import seedu.edrecord.model.Model;
 import seedu.edrecord.model.assignment.Assignment;
 import seedu.edrecord.model.assignment.Grade;
+import seedu.edrecord.model.assignment.Grade.GradeStatus;
 import seedu.edrecord.model.assignment.Score;
 import seedu.edrecord.model.module.ModuleGroupMap;
 import seedu.edrecord.model.name.Name;
@@ -49,6 +50,8 @@ public class GradeCommand extends Command {
     public static final String MESSAGE_NO_SUCH_ASSIGNMENT = "There is no assignment with this name";
     public static final String MESSAGE_SCORE_GREATER_THAN_MAX = "Student's score is greater than the "
             + "maximum score for this assignment";
+    public static final String MESSAGE_STATUS_SCORE_MISMATCH = "Assignment has not been graded and should not "
+            + "have a score.";
 
     private final Index index;
     private final Name name;
@@ -88,12 +91,16 @@ public class GradeCommand extends Command {
         Assignment assignment = model.searchAssignment(name)
                 .orElseThrow(() -> new CommandException(MESSAGE_NO_SUCH_ASSIGNMENT));
 
-        // Check if score is more than the assignment's maximum score.
+        // Check if ungraded assignment has score or score is more than the assignment's maximum score.
         if (grade.getScore().isPresent()) {
-            Score thisScore = grade.getScore().get();
-            Score maxScore = assignment.getMaxScore();
-            if (thisScore.compareTo(maxScore) > 0) {
-                throw new CommandException(MESSAGE_SCORE_GREATER_THAN_MAX);
+            if (grade.getStatus() == GradeStatus.GRADED) {
+                Score thisScore = grade.getScore().get();
+                Score maxScore = assignment.getMaxScore();
+                if (thisScore.compareTo(maxScore) > 0) {
+                    throw new CommandException(MESSAGE_SCORE_GREATER_THAN_MAX);
+                }
+            } else {
+                throw new CommandException(MESSAGE_STATUS_SCORE_MISMATCH);
             }
         }
 

--- a/src/main/java/seedu/edrecord/model/assignment/Grade.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Grade.java
@@ -41,9 +41,9 @@ public class Grade {
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("Status: ").append(status).append(", ");
+        builder.append("Status: ").append(status);
         if (score.isPresent()) {
-            builder.append("Score: ");
+            builder.append(", Score: ");
             score.ifPresent(builder::append);
         }
         return builder.toString();


### PR DESCRIPTION
- Previously, users could add a score to an assignment that was not graded. Now, EdRecord will prompt the user if they are trying to add a score to an assignment that does not have `Graded` status (fix #127, fix #138, fix #177)
- Fixed #125