### PR TITLE
Fix total assignment weightage in module can exceed 100%

### DIFF
--- a/src/main/java/seedu/edrecord/logic/commands/AddAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/AddAssignmentCommand.java
@@ -25,8 +25,9 @@ public class AddAssignmentCommand extends Command {
             + PREFIX_SCORE + "50";
 
     public static final String MESSAGE_SUCCESS = "New assignment added: %1$s";
-
     public static final String MESSAGE_DUPLICATE_ASSIGNMENT = "This assignment already exists in this module";
+    public static final String MESSAGE_TOTAL_WEIGHTAGE_EXCEEDS_100 =
+            "Adding this assignment brings the total module weightage above 100%";
 
     private final Assignment toAdd;
 
@@ -46,6 +47,9 @@ public class AddAssignmentCommand extends Command {
         }
         if (model.hasAssignmentInCurrentModule(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
+        }
+        if (model.isTotalWeightageExceeded(toAdd)) {
+            throw new CommandException(MESSAGE_TOTAL_WEIGHTAGE_EXCEEDS_100);
         }
         model.addAssignment(toAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));

--- a/src/main/java/seedu/edrecord/model/Model.java
+++ b/src/main/java/seedu/edrecord/model/Model.java
@@ -163,6 +163,12 @@ public interface Model {
     boolean hasAssignmentInCurrentModule(Assignment assignment);
 
     /**
+     * Returns true if adding the assignment {@code toAdd} will bring the total weightage
+     * of all assignments under the currently selected module to above 100%.
+     */
+    boolean isTotalWeightageExceeded(Assignment toAdd);
+
+    /**
      * Returns true if any existing grade of the original assignment {@code current} is
      * higher than the maximum score of {@code editedAssignment}. Both assignments
      * must be under the currently selected module.

--- a/src/main/java/seedu/edrecord/model/ModelManager.java
+++ b/src/main/java/seedu/edrecord/model/ModelManager.java
@@ -254,6 +254,14 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean isTotalWeightageExceeded(Assignment toAdd) {
+        if (!hasSelectedModule()) {
+            return false;
+        }
+        return selectedModule.get().isTotalWeightageExceeded(toAdd);
+    }
+
+    @Override
     public boolean hasHigherGradeInCurrentModule(Assignment current, Assignment editedAssignment) {
         if (!hasSelectedModule()) {
             return false;

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -17,8 +17,7 @@ public class Assignment {
      * Constructs an {@code Assignment}. Every field must be present and not null.
      *
      * @param name      The assignment name, must be unique across the module.
-     * @param weightage The assignment weightage in percentage. It is <em>not</em> guaranteed that
-     *                  the total weightage of all assignments in the module sum to 100%.
+     * @param weightage The assignment weightage in percentage.
      * @param maxScore  The maximum score for the assignment.
      */
     public Assignment(Name name, Weightage weightage, Score maxScore) {

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -54,6 +54,13 @@ public class Assignment {
                 && otherAssignment.getName().equals(getName());
     }
 
+    /**
+     * Returns true if this assignment has a higher weightage than the other assignment.
+     */
+    public boolean hasHigherWeightage(Assignment other) {
+        return weightage.compareTo(other.weightage) > 0;
+    }
+
     @Override
     public String toString() {
         return String.format("%s - Weightage: %s, Maximum Score: %s", name, weightage, maxScore);

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -27,6 +27,8 @@ import seedu.edrecord.model.name.Name;
  */
 public class UniqueAssignmentList implements Iterable<Assignment> {
 
+    private static final Weightage maximumTotalWeightage = new Weightage("100");
+
     private final ObservableList<Assignment> internalList = FXCollections.observableArrayList();
     private final ObservableList<Assignment> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
@@ -44,7 +46,8 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
      * the total weightage of all assignments in this list to above 100%.
      */
     public boolean isTotalWeightageExceeded(Assignment toAdd) {
-        return getTotalWeightage() + toAdd.getWeightage().weightage > 100;
+        Weightage addedWeightage = getTotalAddedWeightage(toAdd);
+        return addedWeightage.compareTo(maximumTotalWeightage) > 0;
     }
 
     /**
@@ -165,14 +168,16 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
-     * Returns the total weightage of all assignments in this list.
+     * Returns the total weightage of all assignments in this list, plus
+     * the weightage of assignment {@code toAdd}.
      */
-    private Float getTotalWeightage() {
+    private Weightage getTotalAddedWeightage(Assignment toAdd) {
         Float total = 0f;
         for (Assignment assignment : internalList) {
             total += assignment.getWeightage().weightage;
         }
-        return total;
+        total += toAdd.getWeightage().weightage;
+        return new Weightage(String.valueOf(total));
     }
 }
 

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -40,6 +40,14 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
+     * Returns true if adding the assignment {@code toAdd} will bring
+     * the total weightage of all assignments in this list to above 100%.
+     */
+    public boolean isTotalWeightageExceeded(Assignment toAdd) {
+        return getTotalWeightage() + toAdd.getWeightage().weightage > 100;
+    }
+
+    /**
      * Adds an assignment to the list.
      * The assignment must not already exist in the list.
      * @param toAdd The assignment to be added.
@@ -154,6 +162,17 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
             }
         }
         return true;
+    }
+
+    /**
+     * Returns the total weightage of all assignments in this list.
+     */
+    private Float getTotalWeightage() {
+        Float total = 0f;
+        for (Assignment assignment : internalList) {
+            total += assignment.getWeightage().weightage;
+        }
+        return total;
     }
 }
 

--- a/src/main/java/seedu/edrecord/model/assignment/Weightage.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Weightage.java
@@ -7,7 +7,7 @@ import static seedu.edrecord.commons.util.AppUtil.checkArgument;
  * Represents an Assignment's weightage in edrecord.
  * Guarantees: immutable; is valid as declared in {@link #isValidWeightage(String)}
  */
-public class Weightage {
+public class Weightage implements Comparable<Weightage> {
     public static final String MESSAGE_CONSTRAINTS =
             "Assignment weightage should be a non-negative integer or float (max 2 decimal numbers) from 0 to 100";
 
@@ -39,6 +39,11 @@ public class Weightage {
     @Override
     public String toString() {
         return String.format("%.2f%%", weightage);
+    }
+
+    @Override
+    public int compareTo(Weightage other) {
+        return this.weightage.compareTo(other.weightage);
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -156,6 +156,14 @@ public class Module {
     }
 
     /**
+     * Returns true if adding the assignment {@code toAdd} will bring
+     * the total weightage of all assignments to above 100%.
+     */
+    public boolean isTotalWeightageExceeded(Assignment toAdd) {
+        return assignmentList.isTotalWeightageExceeded(toAdd);
+    }
+
+    /**
      * Returns an {@code Optional} containing the assignment with the given name, if it exists.
      */
     public Optional<Assignment> searchAssignment(Name name) {

--- a/src/test/java/seedu/edrecord/logic/commands/AddAssignmentCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/AddAssignmentCommandTest.java
@@ -254,6 +254,11 @@ public class AddAssignmentCommandTest {
         }
 
         @Override
+        public boolean isTotalWeightageExceeded(Assignment toAdd) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public List<Assignment> getAssignmentList() {
             throw new AssertionError("This method should not be called.");
         }
@@ -332,6 +337,14 @@ public class AddAssignmentCommandTest {
         public boolean hasAssignmentInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
             return assignmentsAdded.stream().anyMatch(assignment::isSameAssignment);
+        }
+
+        @Override
+        public boolean isTotalWeightageExceeded(Assignment toAdd) {
+            double totalWeightage = assignmentsAdded.stream()
+                    .mapToDouble(assignment -> assignment.getWeightage().weightage)
+                    .sum();
+            return totalWeightage > 100;
         }
 
         @Override

--- a/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
@@ -236,6 +236,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean isTotalWeightageExceeded(Assignment toAdd) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public List<Assignment> getAssignmentList() {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Previously, the user could add/edit an assignment that makes the total weightage of the module exceed 100%. This PR makes sure that the total weightage never exceeds 100%, by disallowing any adding/editing that will violate this constraint.

Closes #173 (and its duplicate #164).