### PR TITLE
Add ID field to assignments

### DIFF
--- a/src/main/java/seedu/edrecord/commons/core/Messages.java
+++ b/src/main/java/seedu/edrecord/commons/core/Messages.java
@@ -8,7 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX = "The assignment index provided is invalid";
+    public static final String MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX = "The assignment ID provided is invalid";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_VIEW_CHANGED = "Now viewing %s.";
     public static final String MESSAGE_NO_MODULE_SELECTED = "No module selected. Please cd into a module first";

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
@@ -24,10 +24,10 @@ public class DeleteAssignmentCommand extends Command {
 
     public static final String MESSAGE_DELETE_ASSIGNMENT_SUCCESS = "Deleted assignment: %1$s";
 
-    private final Index targetIndex;
+    private final Index index;
 
-    public DeleteAssignmentCommand(Index targetIndex) {
-        this.targetIndex = targetIndex;
+    public DeleteAssignmentCommand(Index index) {
+        this.index = index;
     }
 
     @Override
@@ -39,19 +39,22 @@ public class DeleteAssignmentCommand extends Command {
         }
         List<Assignment> assignmentList = model.getAssignmentList();
 
-        if (targetIndex.getZeroBased() >= assignmentList.size()) {
+        if (index.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment assignmentToDelete = assignmentList.get(targetIndex.getZeroBased());
-        model.deleteAssignment(assignmentToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_ASSIGNMENT_SUCCESS, assignmentToDelete));
+        Assignment asgToDelete = assignmentList.stream()
+                .filter(asg -> asg.getId() == index.getOneBased())
+                .findFirst()
+                .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
+        model.deleteAssignment(asgToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_ASSIGNMENT_SUCCESS, asgToDelete));
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteAssignmentCommand // instanceof handles nulls
-                && targetIndex.equals(((DeleteAssignmentCommand) other).targetIndex)); // state check
+                && index.equals(((DeleteAssignmentCommand) other).index)); // state check
     }
 }

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
@@ -75,9 +75,7 @@ public class DeleteGradeCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment assignment = assignmentList.stream()
-                .filter(asg -> asg.getId() == id.getOneBased())
-                .findFirst()
+        Assignment assignment = model.getAssignment(id.getOneBased())
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
         Person personToEdit = lastShownList.get(index.getZeroBased());

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
@@ -2,7 +2,7 @@ package seedu.edrecord.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.core.Messages.MESSAGE_NO_MODULE_SELECTED;
-import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.edrecord.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
@@ -33,27 +33,25 @@ public class DeleteGradeCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a grade from the student "
             + "identified by the index number used in the displayed student list. \n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_NAME + "ASSIGNMENT NAME \n"
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_NAME + "Assignment 2";
+            + PREFIX_ID + "ASSIGNMENT ID \n"
+            + "Example: " + COMMAND_WORD + " 1 " + PREFIX_ID + "4";
 
     public static final String MESSAGE_SUCCESS = "Deleted grade %s \nfor assignment: %s \nfor student: %s";
-    public static final String MESSAGE_NO_SUCH_ASSIGNMENT = "There is no assignment with this name";
-    public static final String MESSAGE_NO_SUCH_GRADE = "There is no grade for this assignment";
+    public static final String MESSAGE_NO_SUCH_GRADE = "There is no grade for this assignment.";
 
     private final Index index;
-    private final Name name;
+    private final Index id;
 
     /**
      * @param index Index of the student to grade.
-     * @param name  Name of the assignment to grade.
+     * @param id    ID of the assignment to grade.
      */
-    public DeleteGradeCommand(Index index, Name name) {
+    public DeleteGradeCommand(Index index, Index id) {
         requireNonNull(index);
-        requireNonNull(name);
+        requireNonNull(id);
 
         this.index = index;
-        this.name = name;
+        this.id = id;
     }
 
     @Override
@@ -71,9 +69,16 @@ public class DeleteGradeCommand extends Command {
             throw new CommandException(MESSAGE_NO_MODULE_SELECTED);
         }
 
-        // Get assignment
-        Assignment assignment = model.searchAssignment(name)
-                .orElseThrow(() -> new CommandException(MESSAGE_NO_SUCH_ASSIGNMENT));
+        List<Assignment> assignmentList = model.getAssignmentList();
+
+        if (id.getOneBased() >= model.getAssignmentCounter()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
+        }
+
+        Assignment assignment = assignmentList.stream()
+                .filter(asg -> asg.getId() == id.getOneBased())
+                .findFirst()
+                .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
         Person personToEdit = lastShownList.get(index.getZeroBased());
         AssignmentGradeMap grades = personToEdit.getGrades();
@@ -123,7 +128,6 @@ public class DeleteGradeCommand extends Command {
 
         // state check
         DeleteGradeCommand e = (DeleteGradeCommand) other;
-        return index.equals(e.index)
-                && name.equals(e.name);
+        return index.equals(e.index) && id.equals(id);
     }
 }

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
@@ -70,8 +70,6 @@ public class DeleteGradeCommand extends Command {
             throw new CommandException(MESSAGE_NO_MODULE_SELECTED);
         }
 
-        List<Assignment> assignmentList = model.getAssignmentList();
-
         if (assignmentId.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteGradeCommand.java
@@ -32,6 +32,7 @@ public class DeleteGradeCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a grade from the student "
             + "identified by the index number used in the displayed student list. \n"
+            + "Reference the assignment using the assignment ID displayed in the assignments view.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ID + "ASSIGNMENT ID \n"
             + "Example: " + COMMAND_WORD + " 1 " + PREFIX_ID + "4";
@@ -39,19 +40,19 @@ public class DeleteGradeCommand extends Command {
     public static final String MESSAGE_SUCCESS = "Deleted grade %s \nfor assignment: %s \nfor student: %s";
     public static final String MESSAGE_NO_SUCH_GRADE = "There is no grade for this assignment.";
 
-    private final Index index;
-    private final Index id;
+    private final Index studentIndex;
+    private final Index assignmentId;
 
     /**
-     * @param index Index of the student to grade.
-     * @param id    ID of the assignment to grade.
+     * @param studentIndex Index of the student to grade.
+     * @param assignmentId    ID of the assignment to grade.
      */
-    public DeleteGradeCommand(Index index, Index id) {
-        requireNonNull(index);
-        requireNonNull(id);
+    public DeleteGradeCommand(Index studentIndex, Index assignmentId) {
+        requireNonNull(studentIndex);
+        requireNonNull(assignmentId);
 
-        this.index = index;
-        this.id = id;
+        this.studentIndex = studentIndex;
+        this.assignmentId = assignmentId;
     }
 
     @Override
@@ -60,7 +61,7 @@ public class DeleteGradeCommand extends Command {
         List<Person> lastShownList = model.getFilteredPersonList();
 
         // Check for valid index
-        if (index.getZeroBased() >= lastShownList.size()) {
+        if (studentIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
@@ -71,14 +72,14 @@ public class DeleteGradeCommand extends Command {
 
         List<Assignment> assignmentList = model.getAssignmentList();
 
-        if (id.getOneBased() >= model.getAssignmentCounter()) {
+        if (assignmentId.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment assignment = model.getAssignment(id.getOneBased())
+        Assignment assignment = model.getAssignment(assignmentId.getOneBased())
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
-        Person personToEdit = lastShownList.get(index.getZeroBased());
+        Person personToEdit = lastShownList.get(studentIndex.getZeroBased());
         AssignmentGradeMap grades = personToEdit.getGrades();
         Grade toRemove = grades.findGrade(assignment);
         if (toRemove == null) {
@@ -126,6 +127,6 @@ public class DeleteGradeCommand extends Command {
 
         // state check
         DeleteGradeCommand e = (DeleteGradeCommand) other;
-        return index.equals(e.index) && id.equals(id);
+        return studentIndex.equals(e.studentIndex) && assignmentId.equals(assignmentId);
     }
 }

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -72,12 +72,11 @@ public class EditAssignmentCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment asgToEdit = assignmentList.stream()
-                .filter(asg -> asg.getId() == index.getOneBased())
-                .findFirst()
-                .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
+        Assignment asgToEdit = assignmentList.get(index.getZeroBased());
 
-        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor);
+        int id = model.getAssignmentCounter();
+
+        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor, id);
 
         if (model.hasSameNameInCurrentModule(editedAsg)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
@@ -95,6 +94,7 @@ public class EditAssignmentCommand extends Command {
         }
 
         model.setAssignment(asgToEdit, editedAsg);
+        model.setAssignmentCounter(id + 1);
         return new CommandResult(String.format(MESSAGE_EDIT_ASSIGNMENT_SUCCESS, editedAsg));
     }
 
@@ -103,13 +103,12 @@ public class EditAssignmentCommand extends Command {
      * edited with {@code editDescriptor}.
      */
     private static Assignment createEditedAssignment(Assignment toEdit,
-                                                     EditAssignmentDescriptor editDescriptor) {
+                                                     EditAssignmentDescriptor editDescriptor, int id) {
         requireNonNull(toEdit);
 
         Name updatedName = editDescriptor.getName().orElse(toEdit.getName());
         Weightage updatedWeightage = editDescriptor.getWeightage().orElse(toEdit.getWeightage());
         Score updatedMaxScore = editDescriptor.getMaxScore().orElse(toEdit.getMaxScore());
-        int id = toEdit.getId();
 
         return new Assignment(updatedName, updatedWeightage, updatedMaxScore, id);
     }

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -73,7 +73,10 @@ public class EditAssignmentCommand extends Command {
         }
 
         Assignment asgToEdit = assignmentList.get(index.getZeroBased());
-        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor);
+
+        int id = model.getAssignmentCounter();
+
+        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor, id);
 
         if (model.hasAssignmentInCurrentModule(editedAsg)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
@@ -91,6 +94,7 @@ public class EditAssignmentCommand extends Command {
         }
 
         model.setAssignment(asgToEdit, editedAsg);
+        model.setAssignmentCounter(id + 1);
         return new CommandResult(String.format(MESSAGE_EDIT_ASSIGNMENT_SUCCESS, editedAsg));
     }
 
@@ -98,14 +102,15 @@ public class EditAssignmentCommand extends Command {
      * Creates and returns an {@code Assignment} with the details of {@code toEdit}
      * edited with {@code editDescriptor}.
      */
-    private static Assignment createEditedAssignment(Assignment toEdit, EditAssignmentDescriptor editDescriptor) {
+    private static Assignment createEditedAssignment(Assignment toEdit,
+                                                     EditAssignmentDescriptor editDescriptor, int id) {
         requireNonNull(toEdit);
 
         Name updatedName = editDescriptor.getName().orElse(toEdit.getName());
         Weightage updatedWeightage = editDescriptor.getWeightage().orElse(toEdit.getWeightage());
         Score updatedMaxScore = editDescriptor.getMaxScore().orElse(toEdit.getMaxScore());
 
-        return new Assignment(updatedName, updatedWeightage, updatedMaxScore);
+        return new Assignment(updatedName, updatedWeightage, updatedMaxScore, id);
     }
 
     /**

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -68,17 +68,18 @@ public class EditAssignmentCommand extends Command {
         }
         List<Assignment> assignmentList = model.getSelectedModule().getValue().getAssignmentList();
 
-        if (index.getZeroBased() >= assignmentList.size()) {
+        if (index.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment asgToEdit = assignmentList.get(index.getZeroBased());
+        Assignment asgToEdit = assignmentList.stream()
+                .filter(asg -> asg.getId() == index.getOneBased())
+                .findFirst()
+                .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
-        int id = model.getAssignmentCounter();
+        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor);
 
-        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor, id);
-
-        if (model.hasAssignmentInCurrentModule(editedAsg)) {
+        if (model.hasSameNameInCurrentModule(editedAsg)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
         }
 
@@ -94,7 +95,6 @@ public class EditAssignmentCommand extends Command {
         }
 
         model.setAssignment(asgToEdit, editedAsg);
-        model.setAssignmentCounter(id + 1);
         return new CommandResult(String.format(MESSAGE_EDIT_ASSIGNMENT_SUCCESS, editedAsg));
     }
 
@@ -103,12 +103,13 @@ public class EditAssignmentCommand extends Command {
      * edited with {@code editDescriptor}.
      */
     private static Assignment createEditedAssignment(Assignment toEdit,
-                                                     EditAssignmentDescriptor editDescriptor, int id) {
+                                                     EditAssignmentDescriptor editDescriptor) {
         requireNonNull(toEdit);
 
         Name updatedName = editDescriptor.getName().orElse(toEdit.getName());
         Weightage updatedWeightage = editDescriptor.getWeightage().orElse(toEdit.getWeightage());
         Score updatedMaxScore = editDescriptor.getMaxScore().orElse(toEdit.getMaxScore());
+        int id = toEdit.getId();
 
         return new Assignment(updatedName, updatedWeightage, updatedMaxScore, id);
     }

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -121,7 +121,7 @@ public class EditAssignmentCommand extends Command {
     private static Assignment createDeltaAssignment(Assignment edited, Assignment current) {
         Weightage deltaWeightage = new Weightage(
                 String.valueOf(edited.getWeightage().weightage - current.getWeightage().weightage));
-        return new Assignment(edited.getName(), deltaWeightage, edited.getMaxScore());
+        return new Assignment(edited.getName(), deltaWeightage, edited.getMaxScore(), current.getId());
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -72,11 +72,12 @@ public class EditAssignmentCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment asgToEdit = assignmentList.get(index.getZeroBased());
+        Assignment asgToEdit = assignmentList.stream()
+                .filter(asg -> asg.getId() == index.getOneBased())
+                .findFirst()
+                .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
-        int id = model.getAssignmentCounter();
-
-        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor, id);
+        Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor);
 
         if (model.hasSameNameInCurrentModule(editedAsg)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
@@ -94,7 +95,6 @@ public class EditAssignmentCommand extends Command {
         }
 
         model.setAssignment(asgToEdit, editedAsg);
-        model.setAssignmentCounter(id + 1);
         return new CommandResult(String.format(MESSAGE_EDIT_ASSIGNMENT_SUCCESS, editedAsg));
     }
 
@@ -103,12 +103,13 @@ public class EditAssignmentCommand extends Command {
      * edited with {@code editDescriptor}.
      */
     private static Assignment createEditedAssignment(Assignment toEdit,
-                                                     EditAssignmentDescriptor editDescriptor, int id) {
+                                                     EditAssignmentDescriptor editDescriptor) {
         requireNonNull(toEdit);
 
         Name updatedName = editDescriptor.getName().orElse(toEdit.getName());
         Weightage updatedWeightage = editDescriptor.getWeightage().orElse(toEdit.getWeightage());
         Score updatedMaxScore = editDescriptor.getMaxScore().orElse(toEdit.getMaxScore());
+        int id = toEdit.getId();
 
         return new Assignment(updatedName, updatedWeightage, updatedMaxScore, id);
     }

--- a/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
@@ -47,7 +47,6 @@ public class GradeCommand extends Command {
             + PREFIX_SCORE + "73 ";
 
     public static final String MESSAGE_SUCCESS = "Graded student: %s \nfor assignment: %s \nwith grade: %s";
-    public static final String MESSAGE_NO_SUCH_ASSIGNMENT = "There is no assignment with this name";
     public static final String MESSAGE_SCORE_GREATER_THAN_MAX = "Student's score is greater than the "
             + "maximum score for this assignment";
     public static final String MESSAGE_STATUS_SCORE_MISMATCH = "Assignment has not been graded and should not "

--- a/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
@@ -92,9 +92,7 @@ public class GradeCommand extends Command {
         if (id.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
-        Assignment assignment = assignmentList.stream()
-                .filter(asg -> asg.getId() == id.getOneBased())
-                .findFirst()
+        Assignment assignment = model.getAssignment(id.getOneBased())
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
         // Check if ungraded assignment has score or score is more than the assignment's maximum score.

--- a/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
@@ -87,9 +87,6 @@ public class GradeCommand extends Command {
             throw new CommandException(MESSAGE_NO_MODULE_SELECTED);
         }
 
-        // Get assignment
-        List<Assignment> assignmentList = model.getAssignmentList();
-
         if (id.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }

--- a/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
@@ -36,6 +36,7 @@ public class GradeCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a grade to the student "
             + "identified by the index number used in the displayed student list. \n"
+            + "Reference the assignment using the assignment ID displayed in the assignments view.\n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_ID + "ASSIGNMENT ID "
             + PREFIX_STATUS + "STATUS "

--- a/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/GradeCommand.java
@@ -2,7 +2,7 @@ package seedu.edrecord.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.core.Messages.MESSAGE_NO_MODULE_SELECTED;
-import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_SCORE;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_STATUS;
 import static seedu.edrecord.model.Model.PREDICATE_SHOW_ALL_PERSONS;
@@ -37,12 +37,12 @@ public class GradeCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns a grade to the student "
             + "identified by the index number used in the displayed student list. \n"
             + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_NAME + "ASSIGNMENT NAME "
+            + PREFIX_ID + "ASSIGNMENT ID "
             + PREFIX_STATUS + "STATUS "
             + "[" + PREFIX_SCORE + "SCORE] \n"
             + "Status has 3 possible inputs: Not submitted, Submitted or Graded. \n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_NAME + "Assignment 2 "
+            + PREFIX_ID + "3 "
             + PREFIX_STATUS + "Graded "
             + PREFIX_SCORE + "73 ";
 
@@ -54,21 +54,21 @@ public class GradeCommand extends Command {
             + "have a score.";
 
     private final Index index;
-    private final Name name;
+    private final Index id;
     private final Grade grade;
 
     /**
      * @param index Index of the student to grade.
-     * @param name  Name of the assignment to grade.
+     * @param id    ID of the assignment to grade.
      * @param grade Grade of the assignment.
      */
-    public GradeCommand(Index index, Name name, Grade grade) {
+    public GradeCommand(Index index, Index id, Grade grade) {
         requireNonNull(index);
-        requireNonNull(name);
+        requireNonNull(id);
         requireNonNull(grade);
 
         this.index = index;
-        this.name = name;
+        this.id = id;
         this.grade = grade;
     }
 
@@ -88,8 +88,15 @@ public class GradeCommand extends Command {
         }
 
         // Get assignment
-        Assignment assignment = model.searchAssignment(name)
-                .orElseThrow(() -> new CommandException(MESSAGE_NO_SUCH_ASSIGNMENT));
+        List<Assignment> assignmentList = model.getAssignmentList();
+
+        if (id.getOneBased() >= model.getAssignmentCounter()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
+        }
+        Assignment assignment = assignmentList.stream()
+                .filter(asg -> asg.getId() == id.getOneBased())
+                .findFirst()
+                .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
         // Check if ungraded assignment has score or score is more than the assignment's maximum score.
         if (grade.getScore().isPresent()) {
@@ -148,7 +155,7 @@ public class GradeCommand extends Command {
         // state check
         GradeCommand e = (GradeCommand) other;
         return index.equals(e.index)
-                && name.equals(e.name)
+                && id.equals(e.id)
                 && grade.equals(e.grade);
     }
 }

--- a/src/main/java/seedu/edrecord/logic/commands/MakeAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/MakeAssignmentCommand.java
@@ -2,6 +2,7 @@ package seedu.edrecord.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.core.Messages.MESSAGE_NO_MODULE_SELECTED;
+import static seedu.edrecord.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_SCORE;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_WEIGHTAGE;
@@ -9,6 +10,9 @@ import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_WEIGHTAGE;
 import seedu.edrecord.logic.commands.exceptions.CommandException;
 import seedu.edrecord.model.Model;
 import seedu.edrecord.model.assignment.Assignment;
+import seedu.edrecord.model.assignment.Score;
+import seedu.edrecord.model.assignment.Weightage;
+import seedu.edrecord.model.name.Name;
 
 public class MakeAssignmentCommand extends Command {
 
@@ -29,19 +33,25 @@ public class MakeAssignmentCommand extends Command {
     public static final String MESSAGE_TOTAL_WEIGHTAGE_EXCEEDS_100 =
             "Adding this assignment brings the total module weightage above 100%";
 
-    private final Assignment toAdd;
+    private final Name name;
+    private final Weightage weightage;
+    private final Score maxScore;
 
     /**
      * Creates an MakeAssignmentCommand to add the specified {@code Assignment}
      */
-    public MakeAssignmentCommand(Assignment assignment) {
-        requireNonNull(assignment);
-        toAdd = assignment;
+    public MakeAssignmentCommand(Name name, Weightage weightage, Score maxScore) {
+        requireAllNonNull(name, weightage, maxScore);
+        this.name = name;
+        this.weightage = weightage;
+        this.maxScore = maxScore;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
+        int id = model.getAssignmentCounter();
+        Assignment toAdd = new Assignment(name, weightage, maxScore, id);
         if (!model.hasSelectedModule()) {
             throw new CommandException(MESSAGE_NO_MODULE_SELECTED);
         }
@@ -52,6 +62,7 @@ public class MakeAssignmentCommand extends Command {
             throw new CommandException(MESSAGE_TOTAL_WEIGHTAGE_EXCEEDS_100);
         }
         model.addAssignment(toAdd);
+        model.setAssignmentCounter(id + 1);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 
@@ -59,6 +70,8 @@ public class MakeAssignmentCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof MakeAssignmentCommand // instanceof handles nulls
-                && toAdd.equals(((MakeAssignmentCommand) other).toAdd));
+                && name.equals(((MakeAssignmentCommand) other).name)
+                && weightage.equals(((MakeAssignmentCommand) other).weightage)
+                && maxScore.equals(((MakeAssignmentCommand) other).maxScore));
     }
 }

--- a/src/main/java/seedu/edrecord/logic/commands/MakeAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/MakeAssignmentCommand.java
@@ -62,7 +62,6 @@ public class MakeAssignmentCommand extends Command {
             throw new CommandException(MESSAGE_TOTAL_WEIGHTAGE_EXCEEDS_100);
         }
         model.addAssignment(toAdd);
-        model.setAssignmentCounter(id + 1);
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/seedu/edrecord/logic/commands/MakeAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/MakeAssignmentCommand.java
@@ -55,7 +55,7 @@ public class MakeAssignmentCommand extends Command {
         if (!model.hasSelectedModule()) {
             throw new CommandException(MESSAGE_NO_MODULE_SELECTED);
         }
-        if (model.hasAssignmentInCurrentModule(toAdd)) {
+        if (model.hasSameNameInCurrentModule(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
         }
         if (model.isTotalWeightageExceeded(toAdd)) {

--- a/src/main/java/seedu/edrecord/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/edrecord/logic/parser/CliSyntax.java
@@ -16,5 +16,5 @@ public class CliSyntax {
     public static final Prefix PREFIX_WEIGHTAGE = new Prefix("w/");
     public static final Prefix PREFIX_SCORE = new Prefix("s/");
     public static final Prefix PREFIX_STATUS = new Prefix("st/");
-
+    public static final Prefix PREFIX_ID = new Prefix("id/");
 }

--- a/src/main/java/seedu/edrecord/logic/parser/DeleteGradeCommandParser.java
+++ b/src/main/java/seedu/edrecord/logic/parser/DeleteGradeCommandParser.java
@@ -3,12 +3,11 @@ package seedu.edrecord.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.edrecord.logic.parser.AddCommandParser.arePrefixesPresent;
-import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_ID;
 
 import seedu.edrecord.commons.core.index.Index;
 import seedu.edrecord.logic.commands.DeleteGradeCommand;
 import seedu.edrecord.logic.parser.exceptions.ParseException;
-import seedu.edrecord.model.name.Name;
 
 /**
  * Parses input arguments and creates a new GradeCommand object
@@ -24,9 +23,9 @@ public class DeleteGradeCommandParser implements Parser<DeleteGradeCommand> {
     public DeleteGradeCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+                ArgumentTokenizer.tokenize(args, PREFIX_ID);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_ID)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteGradeCommand.MESSAGE_USAGE));
         }
 
@@ -39,8 +38,8 @@ public class DeleteGradeCommandParser implements Parser<DeleteGradeCommand> {
                     DeleteGradeCommand.MESSAGE_USAGE), pe);
         }
 
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Index id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
 
-        return new DeleteGradeCommand(index, name);
+        return new DeleteGradeCommand(index, id);
     }
 }

--- a/src/main/java/seedu/edrecord/logic/parser/GradeCommandParser.java
+++ b/src/main/java/seedu/edrecord/logic/parser/GradeCommandParser.java
@@ -3,7 +3,7 @@ package seedu.edrecord.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.edrecord.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.edrecord.logic.parser.AddCommandParser.arePrefixesPresent;
-import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_SCORE;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_STATUS;
 
@@ -15,7 +15,6 @@ import seedu.edrecord.logic.parser.exceptions.ParseException;
 import seedu.edrecord.model.assignment.Grade;
 import seedu.edrecord.model.assignment.Grade.GradeStatus;
 import seedu.edrecord.model.assignment.Score;
-import seedu.edrecord.model.name.Name;
 
 /**
  * Parses input arguments and creates a new GradeCommand object
@@ -31,9 +30,9 @@ public class GradeCommandParser implements Parser<GradeCommand> {
     public GradeCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_SCORE, PREFIX_STATUS);
+                ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_SCORE, PREFIX_STATUS);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_STATUS)) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_ID, PREFIX_STATUS)) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE));
         }
 
@@ -45,15 +44,17 @@ public class GradeCommandParser implements Parser<GradeCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, GradeCommand.MESSAGE_USAGE), pe);
         }
 
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+        Index id = ParserUtil.parseId(argMultimap.getValue(PREFIX_ID).get());
+
         Optional<Score> score;
         if (argMultimap.getValue(PREFIX_SCORE).isPresent()) {
             score = Optional.of(ParserUtil.parseScore(argMultimap.getValue(PREFIX_SCORE).get()));
         } else {
             score = Optional.empty();
         }
+
         GradeStatus status = ParserUtil.parseStatus(argMultimap.getValue(PREFIX_STATUS).get());
         Grade grade = new Grade(score, status);
-        return new GradeCommand(index, name, grade);
+        return new GradeCommand(index, id, grade);
     }
 }

--- a/src/main/java/seedu/edrecord/logic/parser/MakeAssignmentCommandParser.java
+++ b/src/main/java/seedu/edrecord/logic/parser/MakeAssignmentCommandParser.java
@@ -9,7 +9,6 @@ import java.util.stream.Stream;
 
 import seedu.edrecord.logic.commands.MakeAssignmentCommand;
 import seedu.edrecord.logic.parser.exceptions.ParseException;
-import seedu.edrecord.model.assignment.Assignment;
 import seedu.edrecord.model.assignment.Score;
 import seedu.edrecord.model.assignment.Weightage;
 import seedu.edrecord.model.name.Name;
@@ -35,8 +34,7 @@ public class MakeAssignmentCommandParser implements Parser<MakeAssignmentCommand
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Weightage weightage = ParserUtil.parseWeightage(argMultimap.getValue(PREFIX_WEIGHTAGE).get());
         Score maxScore = ParserUtil.parseScore(argMultimap.getValue(PREFIX_SCORE).get());
-        Assignment asg = new Assignment(name, weightage, maxScore);
-        return new MakeAssignmentCommand(asg);
+        return new MakeAssignmentCommand(name, weightage, maxScore);
     }
 
     /**

--- a/src/main/java/seedu/edrecord/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/edrecord/logic/parser/ParserUtil.java
@@ -27,6 +27,7 @@ import seedu.edrecord.model.tag.Tag;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_ID = "ID is not a non-zero unsigned integer.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -211,5 +212,19 @@ public class ParserUtil {
         default:
             throw new ParseException(Grade.MESSAGE_CONSTRAINTS);
         }
+    }
+
+    /**
+     * Parses a {@code String id} into a {@code Index}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code ID} is invalid.
+     */
+    public static Index parseId(String oneBasedIndex) throws ParseException {
+        String trimmedIndex = oneBasedIndex.trim();
+        if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+            throw new ParseException(MESSAGE_INVALID_ID);
+        }
+        return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
 }

--- a/src/main/java/seedu/edrecord/model/Model.java
+++ b/src/main/java/seedu/edrecord/model/Model.java
@@ -160,7 +160,7 @@ public interface Model {
     /**
      * Returns true if the currently selected module contains the given assignment.
      */
-    boolean hasAssignmentInCurrentModule(Assignment assignment);
+    boolean hasSameNameInCurrentModule(Assignment assignment);
 
     /**
      * Returns true if adding the assignment {@code toAdd} will bring the total weightage

--- a/src/main/java/seedu/edrecord/model/Model.java
+++ b/src/main/java/seedu/edrecord/model/Model.java
@@ -2,6 +2,7 @@ package seedu.edrecord.model;
 
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.beans.value.ObservableValue;
@@ -180,6 +181,11 @@ public interface Model {
      * Returns an unmodifiable view of the assignment list under the currently selected module.
      */
     List<Assignment> getAssignmentList();
+
+    /**
+     * Returns the assignment with the given ID.
+     */
+    Optional<Assignment> getAssignment(int id);
 
     /**
      * Adds the given assignment to the currently selected module.

--- a/src/main/java/seedu/edrecord/model/Model.java
+++ b/src/main/java/seedu/edrecord/model/Model.java
@@ -2,7 +2,6 @@ package seedu.edrecord.model;
 
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import javafx.beans.value.ObservableValue;
@@ -12,7 +11,6 @@ import seedu.edrecord.model.assignment.Assignment;
 import seedu.edrecord.model.module.Module;
 import seedu.edrecord.model.module.ModuleSet;
 import seedu.edrecord.model.module.ReadOnlyModuleSystem;
-import seedu.edrecord.model.name.Name;
 import seedu.edrecord.model.person.PartOfModulePredicate;
 import seedu.edrecord.model.person.Person;
 import seedu.edrecord.ui.PersonListPanel;
@@ -61,7 +59,9 @@ public interface Model {
      */
     void setEdRecord(ReadOnlyEdRecord edRecord);
 
-    /** Returns EdRecord */
+    /**
+     * Returns EdRecord
+     */
     ReadOnlyEdRecord getEdRecord();
 
     /**
@@ -143,6 +143,7 @@ public interface Model {
 
     /**
      * Updates the module filter of the filtered person list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void setModuleFilter(PartOfModulePredicate predicate);
@@ -211,6 +212,7 @@ public interface Model {
 
     /**
      * Updates the search filter of the filtered person list to filter by the given {@code predicate}.
+     *
      * @throws NullPointerException if {@code predicate} is null.
      */
     void setSearchFilter(Predicate<Person> predicate);
@@ -222,6 +224,7 @@ public interface Model {
 
     /**
      * Updates the currently selected view to the specified value.
+     *
      * @param newView The new view
      */
     void setSelectedView(PersonListPanel.View newView);

--- a/src/main/java/seedu/edrecord/model/Model.java
+++ b/src/main/java/seedu/edrecord/model/Model.java
@@ -181,11 +181,6 @@ public interface Model {
     List<Assignment> getAssignmentList();
 
     /**
-     * Returns the assignment that matches the given name.
-     */
-    Optional<Assignment> searchAssignment(Name name);
-
-    /**
      * Adds the given assignment to the currently selected module.
      * {@code assignment} must not already exist under the currently selected module.
      */

--- a/src/main/java/seedu/edrecord/model/Model.java
+++ b/src/main/java/seedu/edrecord/model/Model.java
@@ -205,6 +205,16 @@ public interface Model {
     void setAssignment(Assignment target, Assignment editedAssignment);
 
     /**
+     * Returns the counter for this module's assignment ID.
+     */
+    int getAssignmentCounter();
+
+    /**
+     * Sets the counter for this module's assignment ID to the given value.
+     */
+    void setAssignmentCounter(int i);
+
+    /**
      * Updates the search filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */

--- a/src/main/java/seedu/edrecord/model/ModelManager.java
+++ b/src/main/java/seedu/edrecord/model/ModelManager.java
@@ -25,7 +25,6 @@ import seedu.edrecord.model.module.Module;
 import seedu.edrecord.model.module.ModuleSet;
 import seedu.edrecord.model.module.ModuleSystem;
 import seedu.edrecord.model.module.ReadOnlyModuleSystem;
-import seedu.edrecord.model.name.Name;
 import seedu.edrecord.model.person.PartOfModulePredicate;
 import seedu.edrecord.model.person.Person;
 import seedu.edrecord.ui.PersonListPanel;

--- a/src/main/java/seedu/edrecord/model/ModelManager.java
+++ b/src/main/java/seedu/edrecord/model/ModelManager.java
@@ -277,6 +277,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public Optional<Assignment> getAssignment(int id) {
+        return selectedModule.get().getAssignment(id);
+    }
+
+    @Override
     public void addAssignment(Assignment assignment) {
         selectedModule.get().addAssignment(assignment);
         setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/edrecord/model/ModelManager.java
+++ b/src/main/java/seedu/edrecord/model/ModelManager.java
@@ -278,11 +278,6 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Optional<Assignment> searchAssignment(Name name) {
-        return selectedModule.get().searchAssignment(name);
-    }
-
-    @Override
     public void addAssignment(Assignment assignment) {
         selectedModule.get().addAssignment(assignment);
         setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);

--- a/src/main/java/seedu/edrecord/model/ModelManager.java
+++ b/src/main/java/seedu/edrecord/model/ModelManager.java
@@ -248,8 +248,8 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public boolean hasAssignmentInCurrentModule(Assignment assignment) {
-        return hasSelectedModule() && selectedModule.get().hasAssignment(assignment);
+    public boolean hasSameNameInCurrentModule(Assignment assignment) {
+        return hasSelectedModule() && selectedModule.get().hasSameNameAssignment(assignment);
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/ModelManager.java
+++ b/src/main/java/seedu/edrecord/model/ModelManager.java
@@ -288,6 +288,16 @@ public class ModelManager implements Model {
         setSearchFilter(PREDICATE_SHOW_ALL_PERSONS);
     }
 
+    @Override
+    public int getAssignmentCounter() {
+        return selectedModule.get().getAssignmentCounter();
+    }
+
+    @Override
+    public void setAssignmentCounter(int i) {
+        selectedModule.get().setAssignmentCounter(i);
+    }
+
     //=========== Current View =============================================================================
     @Override
     public ObservableValue<PersonListPanel.View> getSelectedView() {

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -71,7 +71,7 @@ public class Assignment {
 
     @Override
     public String toString() {
-        return String.format("%s - Weightage: %s, Maximum Score: %s", name, weightage, maxScore);
+        return String.format("%s - Weightage: %s, Maximum Score: %s, ID: %s", name, weightage, maxScore, id);
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -2,6 +2,8 @@ package seedu.edrecord.model.assignment;
 
 import static seedu.edrecord.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Objects;
+
 import seedu.edrecord.model.name.Name;
 
 /**
@@ -76,12 +78,15 @@ public class Assignment {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Assignment // instanceof handles nulls
-                && id.equals(((Assignment) other).id)); // state check
+                && name.equals(((Assignment) other).name) // state check
+                && weightage.equals(((Assignment) other).weightage)
+                && maxScore.equals(((Assignment) other).maxScore)
+                && id.equals(((Assignment) other).id));
     }
 
     @Override
     public int hashCode() {
-        return id.hashCode();
+        return Objects.hash(name, weightage, maxScore, id);
     }
 
 }

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -54,7 +54,7 @@ public class Assignment {
      *
      * @param otherAssignment The other assignment to compare to.
      */
-    public boolean isSameName(Assignment otherAssignment) {
+    public boolean isSameAssignment(Assignment otherAssignment) {
         if (otherAssignment == this) {
             return true;
         }

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -5,13 +5,14 @@ import static seedu.edrecord.commons.util.CollectionUtil.requireAllNonNull;
 import seedu.edrecord.model.name.Name;
 
 /**
- * Represents an Assignment under a module in edrecord.
+ * Represents an Assignment under a module in EdRecord.
  * Guarantees: immutable, details are present and not null.
  */
 public class Assignment {
     private final Name name;
     private final Weightage weightage;
     private final Score maxScore;
+    private final Integer id;
 
     /**
      * Constructs an {@code Assignment}. Every field must be present and not null.
@@ -19,12 +20,14 @@ public class Assignment {
      * @param name      The assignment name, must be unique across the module.
      * @param weightage The assignment weightage in percentage.
      * @param maxScore  The maximum score for the assignment.
+     * @param id        The unique ID of the assignment.
      */
-    public Assignment(Name name, Weightage weightage, Score maxScore) {
+    public Assignment(Name name, Weightage weightage, Score maxScore, int id) {
         requireAllNonNull(name, weightage, maxScore);
         this.name = name;
         this.weightage = weightage;
         this.maxScore = maxScore;
+        this.id = id;
     }
 
     public Name getName() {
@@ -39,13 +42,17 @@ public class Assignment {
         return maxScore;
     }
 
+    public Integer getId() {
+        return id;
+    }
+
     /**
      * Returns true if both assignments have the same name, i.e. they are considered to have the same identity.
      * This defines a weaker notion of equality between two assignments.
      *
      * @param otherAssignment The other assignment to compare to.
      */
-    public boolean isSameAssignment(Assignment otherAssignment) {
+    public boolean isSameName(Assignment otherAssignment) {
         if (otherAssignment == this) {
             return true;
         }
@@ -69,12 +76,12 @@ public class Assignment {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Assignment // instanceof handles nulls
-                && name.equals(((Assignment) other).name)); // state check
+                && id.equals(((Assignment) other).id)); // state check
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return id.hashCode();
     }
 
 }

--- a/src/main/java/seedu/edrecord/model/assignment/Assignment.java
+++ b/src/main/java/seedu/edrecord/model/assignment/Assignment.java
@@ -59,7 +59,7 @@ public class Assignment {
             return true;
         }
         return otherAssignment != null
-                && otherAssignment.getName().equals(getName());
+                && otherAssignment.name.equalsIgnoreCase(name);
     }
 
     /**

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -20,25 +20,28 @@ import seedu.edrecord.model.name.Name;
  * so as to ensure that the assignment being added or updated is unique in terms of identity in the
  * UniqueAssignmentList. However, the removal of an assignment uses Assignment#equals(Object) so as
  * to ensure that the person with exactly the same fields will be removed.
- *
+ * <p>
  * Supports a minimal set of list operations.
  *
- * @see Assignment#isSameAssignment(Assignment)
+ * @see Assignment#isSameName(Assignment)
  */
 public class UniqueAssignmentList implements Iterable<Assignment> {
+    private static final String INVALID_ID = "ID of this assignment is invalid.";
 
     private static final Weightage maximumTotalWeightage = new Weightage("100");
 
     private final ObservableList<Assignment> internalList = FXCollections.observableArrayList();
     private final ObservableList<Assignment> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+    private int assignmentCounter = 1;
 
     /**
      * Returns true if the list contains an assignment with the same identity as the given argument.
      */
     public boolean contains(Assignment toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameAssignment);
+        return internalList.stream().anyMatch(toCheck::isSameName)
+                || internalList.stream().anyMatch(toCheck::equals);
     }
 
     /**
@@ -53,6 +56,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     /**
      * Adds an assignment to the list.
      * The assignment must not already exist in the list.
+     *
      * @param toAdd The assignment to be added.
      */
     public void add(Assignment toAdd) {
@@ -76,7 +80,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
             throw new AssignmentNotFoundException();
         }
 
-        if (!target.isSameAssignment(editedAssignment) && contains(editedAssignment)) {
+        if (!target.isSameName(editedAssignment) && contains(editedAssignment)) {
             throw new DuplicateAssignmentException();
         }
 
@@ -120,13 +124,27 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
      */
     public Optional<Assignment> searchAssignment(Name name) {
         // Create dummy assignment to search by name
-        Assignment a = new Assignment(name, new Weightage("0"), new Score("0"));
+        Assignment a = new Assignment(name, new Weightage("0"), new Score("0"), 0);
         int index = internalUnmodifiableList.indexOf(a);
         if (index == -1) {
             return Optional.empty();
         } else {
             return Optional.of(internalUnmodifiableList.get(index));
         }
+    }
+
+    /**
+     * Returns the current counter for this module's assignment ID.
+     */
+    public int getAssignmentCounter() {
+        return assignmentCounter;
+    }
+
+    /**
+     * Sets the counter for this module's assignment ID to the given value.
+     */
+    public void setAssignmentCounter(int i) {
+        assignmentCounter = i;
     }
 
     /**
@@ -159,7 +177,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     private boolean assignmentsAreUnique(List<Assignment> assignments) {
         for (int i = 0; i < assignments.size() - 1; i++) {
             for (int j = i + 1; j < assignments.size(); j++) {
-                if (assignments.get(i).isSameAssignment(assignments.get(j))) {
+                if (assignments.get(i).isSameName(assignments.get(j))) {
                     return false;
                 }
             }

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -5,13 +5,11 @@ import static seedu.edrecord.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.edrecord.model.assignment.exceptions.AssignmentNotFoundException;
 import seedu.edrecord.model.assignment.exceptions.DuplicateAssignmentException;
-import seedu.edrecord.model.name.Name;
 
 /**
  * A list of assignments that enforces uniqueness among its elements and does not allow nulls.

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -26,8 +26,6 @@ import seedu.edrecord.model.name.Name;
  * @see Assignment#isSameName(Assignment)
  */
 public class UniqueAssignmentList implements Iterable<Assignment> {
-    private static final String INVALID_ID = "ID of this assignment is invalid.";
-
     private static final Weightage maximumTotalWeightage = new Weightage("100");
 
     private final ObservableList<Assignment> internalList = FXCollections.observableArrayList();
@@ -64,6 +62,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
         if (contains(toAdd)) {
             throw new DuplicateAssignmentException();
         }
+        assignmentCounter++;
         internalList.add(toAdd);
     }
 

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -80,10 +80,6 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
             throw new AssignmentNotFoundException();
         }
 
-        if (!target.isSameName(editedAssignment) && contains(editedAssignment)) {
-            throw new DuplicateAssignmentException();
-        }
-
         internalList.set(index, editedAssignment);
     }
 
@@ -131,6 +127,14 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
         } else {
             return Optional.of(internalUnmodifiableList.get(index));
         }
+    }
+
+    /**
+     * Returns true if there is another assignment with the same name in the list.
+     */
+    public boolean hasSameName(Assignment assignment) {
+        requireNonNull(assignment);
+        return internalList.stream().anyMatch(asg -> !(asg.equals(assignment)) && asg.isSameName(assignment));
     }
 
     /**

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -130,6 +130,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
+<<<<<<< HEAD
      * Returns true if there is another assignment with the same name in the list.
      */
     public boolean hasSameName(Assignment assignment) {
@@ -138,6 +139,8 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
+=======
+>>>>>>> afc49632 (Add ID to assignments)
      * Returns the current counter for this module's assignment ID.
      */
     public int getAssignmentCounter() {

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -130,7 +130,6 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
-<<<<<<< HEAD
      * Returns true if there is another assignment with the same name in the list.
      */
     public boolean hasSameName(Assignment assignment) {
@@ -139,8 +138,6 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
-=======
->>>>>>> afc49632 (Add ID to assignments)
      * Returns the current counter for this module's assignment ID.
      */
     public int getAssignmentCounter() {

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -115,20 +115,6 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     }
 
     /**
-     * Returns an {@code Optional} containing the assignment with the given name, if it exists.
-     */
-    public Optional<Assignment> searchAssignment(Name name) {
-        // Create dummy assignment to search by name
-        Assignment a = new Assignment(name, new Weightage("0"), new Score("0"), 0);
-        int index = internalUnmodifiableList.indexOf(a);
-        if (index == -1) {
-            return Optional.empty();
-        } else {
-            return Optional.of(internalUnmodifiableList.get(index));
-        }
-    }
-
-    /**
      * Returns true if there is another assignment with the same name in the list.
      */
     public boolean hasSameName(Assignment assignment) {

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -21,7 +21,7 @@ import seedu.edrecord.model.assignment.exceptions.DuplicateAssignmentException;
  * <p>
  * Supports a minimal set of list operations.
  *
- * @see Assignment#isSameName(Assignment)
+ * @see Assignment#isSameAssignment(Assignment)
  */
 public class UniqueAssignmentList implements Iterable<Assignment> {
     private static final Weightage maximumTotalWeightage = new Weightage("100");
@@ -29,6 +29,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     private final ObservableList<Assignment> internalList = FXCollections.observableArrayList();
     private final ObservableList<Assignment> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
+
     private int assignmentCounter = 1;
 
     /**
@@ -36,8 +37,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
      */
     public boolean contains(Assignment toCheck) {
         requireNonNull(toCheck);
-        return internalList.stream().anyMatch(toCheck::isSameName)
-                || internalList.stream().anyMatch(toCheck::equals);
+        return internalList.stream().anyMatch(toCheck::isSameAssignment);
     }
 
     /**
@@ -117,7 +117,16 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
      */
     public boolean hasSameName(Assignment assignment) {
         requireNonNull(assignment);
-        return internalList.stream().anyMatch(asg -> !(asg.equals(assignment)) && asg.isSameName(assignment));
+        return internalList.stream().anyMatch(asg -> !(asg.equals(assignment)) && asg.isSameAssignment(assignment));
+    }
+
+    /**
+     * Returns true if there is another assignment with the same ID in the list.
+     */
+    public boolean hasSameId(Assignment assignment) {
+        requireNonNull(assignment);
+        return internalList.stream().anyMatch(asg -> !(asg.equals(assignment))
+                && asg.getId().equals(assignment.getId()));
     }
 
     /**
@@ -164,7 +173,7 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
     private boolean assignmentsAreUnique(List<Assignment> assignments) {
         for (int i = 0; i < assignments.size() - 1; i++) {
             for (int j = i + 1; j < assignments.size(); j++) {
-                if (assignments.get(i).isSameName(assignments.get(j))) {
+                if (assignments.get(i).isSameAssignment(assignments.get(j))) {
                     return false;
                 }
             }

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
 import java.util.Objects;
+import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.edrecord.model.assignment.Assignment;
@@ -177,6 +178,20 @@ public class Module {
      */
     public boolean hasSameNameAssignment(Assignment a) {
         return assignmentList.hasSameName(a);
+    }
+
+    /**
+     * Returns true if the module contains an assignment that has the same ID as the given assignment.
+     */
+    public boolean hasSameIdAssignment(Assignment a) {
+        return assignmentList.hasSameId(a);
+    }
+
+    /**
+     * Gets the assignment with the given ID, if it exists.
+     */
+    public Optional<Assignment> getAssignment(int id) {
+        return getAssignmentList().stream().filter(asg -> asg.getId() == id).findFirst();
     }
 
     /**

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -3,6 +3,7 @@ package seedu.edrecord.model.module;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
+import java.util.Objects;
 
 import javafx.collections.ObservableList;
 import seedu.edrecord.model.assignment.Assignment;
@@ -10,7 +11,6 @@ import seedu.edrecord.model.assignment.UniqueAssignmentList;
 import seedu.edrecord.model.group.Group;
 import seedu.edrecord.model.group.GroupSystem;
 import seedu.edrecord.model.group.ReadOnlyGroupSystem;
-import seedu.edrecord.model.name.Name;
 
 /**
  * Represents a module in EdRecord.

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -3,8 +3,6 @@ package seedu.edrecord.model.module;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
-import java.util.Objects;
-import java.util.Optional;
 
 import javafx.collections.ObservableList;
 import seedu.edrecord.model.assignment.Assignment;
@@ -65,10 +63,6 @@ public class Module {
 
     public String getCode() {
         return code;
-    }
-
-    public GroupSystem getGroupSystem() {
-        return groupSystem;
     }
 
     public boolean hasAnyGroup() {

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -60,6 +60,8 @@ public class Module {
         this.assignmentList = new UniqueAssignmentList();
     }
 
+    //=========== Module Operations ==========================================================================
+
     public String getCode() {
         return code;
     }
@@ -70,20 +72,6 @@ public class Module {
 
     public boolean hasAnyGroup() {
         return groupSystem.hasAnyGroup();
-    }
-
-    /**
-     * Returns a view of this module's assignment list as an unmodifiable {@code ObservableList}.
-     */
-    public ObservableList<Assignment> getAssignmentList() {
-        return assignmentList.asUnmodifiableObservableList();
-    }
-
-    /**
-     * Returns a view of this module's class list as an unmodifiable {@code ObservableList}.
-     */
-    public ObservableList<Group> getGroupList() {
-        return groupSystem.getGroupList();
     }
 
     /**
@@ -113,8 +101,21 @@ public class Module {
         return code.equalsIgnoreCase(otherModule.getCode());
     }
 
+    //=========== Group Operations ===========================================================================
+
+    public GroupSystem getGroupSystem() {
+        return groupSystem;
+    }
+
     public void setGroupSystem(ReadOnlyGroupSystem groupSystem) {
         this.groupSystem.resetData(groupSystem);
+    }
+
+    /**
+     * Returns a view of this module's class list as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Group> getGroupList() {
+        return groupSystem.getGroupList();
     }
 
     /**
@@ -137,26 +138,13 @@ public class Module {
         return groupSystem.getGroup(groupCode);
     }
 
-    /**
-     * Returns true if the module contains an assignment that is equivalent to the given assignment.
-     */
-    public boolean hasAssignment(Assignment a) {
-        return assignmentList.contains(a);
-    }
+    //=========== Assignment Operations ======================================================================
 
     /**
-     * Returns true if adding the assignment {@code toAdd} will bring
-     * the total weightage of all assignments to above 100%.
+     * Returns a view of this module's assignment list as an unmodifiable {@code ObservableList}.
      */
-    public boolean isTotalWeightageExceeded(Assignment toAdd) {
-        return assignmentList.isTotalWeightageExceeded(toAdd);
-    }
-
-    /**
-     * Returns an {@code Optional} containing the assignment with the given name, if it exists.
-     */
-    public Optional<Assignment> searchAssignment(Name name) {
-        return assignmentList.searchAssignment(name);
+    public ObservableList<Assignment> getAssignmentList() {
+        return assignmentList.asUnmodifiableObservableList();
     }
 
     /**
@@ -182,6 +170,42 @@ public class Module {
      */
     public void setAssignment(Assignment target, Assignment editedAssignment) {
         assignmentList.setAssignment(target, editedAssignment);
+    }
+
+    /**
+     * Returns true if the module contains an assignment that is equivalent to the given assignment.
+     */
+    public boolean hasAssignment(Assignment a) {
+        return assignmentList.contains(a);
+    }
+
+    /**
+     * Returns an {@code Optional} containing the assignment with the given name, if it exists.
+     */
+    public Optional<Assignment> searchAssignment(Name name) {
+        return assignmentList.searchAssignment(name);
+    }
+
+    /**
+     * Returns true if adding the assignment {@code toAdd} will bring
+     * the total weightage of all assignments to above 100%.
+     */
+    public boolean isTotalWeightageExceeded(Assignment toAdd) {
+        return assignmentList.isTotalWeightageExceeded(toAdd);
+    }
+
+    /**
+     * Returns the current counter for this module's assignment ID.
+     */
+    public int getAssignmentCounter() {
+        return assignmentList.getAssignmentCounter();
+    }
+
+    /**
+     * Sets the counter for this module's assignment ID to the given value.
+     */
+    public void setAssignmentCounter(int i) {
+        assignmentList.setAssignmentCounter(i);
     }
 
     @Override

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -180,13 +180,6 @@ public class Module {
     }
 
     /**
-     * Returns an {@code Optional} containing the assignment with the given name, if it exists.
-     */
-    public Optional<Assignment> searchAssignment(Name name) {
-        return assignmentList.searchAssignment(name);
-    }
-
-    /**
      * Returns true if adding the assignment {@code toAdd} will bring
      * the total weightage of all assignments to above 100%.
      */

--- a/src/main/java/seedu/edrecord/model/module/Module.java
+++ b/src/main/java/seedu/edrecord/model/module/Module.java
@@ -173,10 +173,10 @@ public class Module {
     }
 
     /**
-     * Returns true if the module contains an assignment that is equivalent to the given assignment.
+     * Returns true if the module contains an assignment that has the same name as the given assignment.
      */
-    public boolean hasAssignment(Assignment a) {
-        return assignmentList.contains(a);
+    public boolean hasSameNameAssignment(Assignment a) {
+        return assignmentList.hasSameName(a);
     }
 
     /**

--- a/src/main/java/seedu/edrecord/model/name/Name.java
+++ b/src/main/java/seedu/edrecord/model/name/Name.java
@@ -38,6 +38,12 @@ public class Name {
         return test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if other name has the same contents even if the letter case is different.
+     */
+    public boolean equalsIgnoreCase(Name other) {
+        return other.name.equalsIgnoreCase(name);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/edrecord/storage/JsonAdaptedAssignment.java
+++ b/src/main/java/seedu/edrecord/storage/JsonAdaptedAssignment.java
@@ -19,16 +19,18 @@ public class JsonAdaptedAssignment {
     private final String name;
     private final String weightage;
     private final String maxScore;
+    private final Integer id;
 
     /**
      * Constructs a {@code JsonAdaptedAssignment} with the given details.
      */
     @JsonCreator
     public JsonAdaptedAssignment(@JsonProperty("name") String name, @JsonProperty("weightage") String weightage,
-                                 @JsonProperty("maxScore") String maxScore) {
+                                 @JsonProperty("maxScore") String maxScore, @JsonProperty("id") Integer id) {
         this.name = name;
         this.weightage = weightage;
         this.maxScore = maxScore;
+        this.id = id;
     }
 
     /**
@@ -38,6 +40,7 @@ public class JsonAdaptedAssignment {
         name = source.getName().name;
         weightage = String.valueOf(source.getWeightage().weightage);
         maxScore = String.valueOf(source.getMaxScore().score);
+        id = source.getId();
     }
 
     /**
@@ -72,7 +75,12 @@ public class JsonAdaptedAssignment {
         }
         final Score modelScore = new Score(maxScore);
 
-        return new Assignment(modelName, modelWeightage, modelScore);
+        if (id == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, "ID"));
+        }
+
+        return new Assignment(modelName, modelWeightage, modelScore, id);
     }
 
 }

--- a/src/main/java/seedu/edrecord/storage/JsonAdaptedGrade.java
+++ b/src/main/java/seedu/edrecord/storage/JsonAdaptedGrade.java
@@ -1,0 +1,91 @@
+package seedu.edrecord.storage;
+
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import seedu.edrecord.commons.exceptions.IllegalValueException;
+import seedu.edrecord.model.assignment.Grade;
+import seedu.edrecord.model.assignment.Score;
+import seedu.edrecord.model.assignment.Weightage;
+
+/**
+ * Jackson-friendly version of {@link Grade}.
+ */
+public class JsonAdaptedGrade {
+
+    public static final String MISSING_FIELD_MESSAGE_FORMAT = "Assignment %s field is missing!";
+
+    private final String status;
+    private final String score;
+    private final Integer id;
+
+    /**
+     * Constructs a {@code JsonAdaptedAssignment} with the given details.
+     */
+    @JsonCreator
+    public JsonAdaptedGrade(@JsonProperty("status") String status,
+                            @JsonProperty("score") String score,
+                            @JsonProperty("id") Integer id) {
+        this.status = status;
+        this.score = score;
+        this.id = id;
+    }
+
+    /**
+     * Converts a given {@code Assignment} into this class for Jackson use.
+     */
+    public JsonAdaptedGrade(int id, Grade source) {
+        this.id = id;
+        this.status = String.valueOf(source.getStatus());
+        this.score = String.valueOf(source.getScore().orElse(null));
+    }
+
+    /**
+     * Converts this {@code JsonAdaptedAssignment} object into the model's {@code Assignment} object.
+     *
+     * @throws IllegalValueException if there were any data constraints violated in the adapted assignment.
+     */
+    public Map.Entry<Integer, Grade> toModelType() throws IllegalValueException {
+        if (id == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "ID"));
+        }
+
+        if (status == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Grade.GradeStatus.class.getSimpleName()));
+        }
+        Grade.GradeStatus modelStatus;
+        switch (status) {
+        case "NOT_SUBMITTED":
+            modelStatus = Grade.GradeStatus.NOT_SUBMITTED;
+            break;
+        case "SUBMITTED":
+            modelStatus = Grade.GradeStatus.SUBMITTED;
+            break;
+        case "GRADED":
+            modelStatus = Grade.GradeStatus.GRADED;
+            break;
+        default:
+            throw new IllegalValueException(Weightage.MESSAGE_CONSTRAINTS);
+        }
+
+        if (score == null) {
+            throw new IllegalValueException(
+                    String.format(MISSING_FIELD_MESSAGE_FORMAT, Score.class.getSimpleName()));
+        }
+        Optional<Score> modelScore;
+        if (score.equals("null")) {
+            modelScore = Optional.empty();
+        } else if (Score.isValidScore(score)) {
+            modelScore = Optional.of(new Score(score));
+        } else {
+            throw new IllegalValueException(Score.MESSAGE_CONSTRAINTS);
+        }
+
+        return Map.entry(id, new Grade(modelScore, modelStatus));
+    }
+
+}

--- a/src/main/java/seedu/edrecord/storage/JsonAdaptedGrade.java
+++ b/src/main/java/seedu/edrecord/storage/JsonAdaptedGrade.java
@@ -23,7 +23,7 @@ public class JsonAdaptedGrade {
     private final Integer id;
 
     /**
-     * Constructs a {@code JsonAdaptedAssignment} with the given details.
+     * Constructs a {@code JsonAdaptedGrade} with the given details.
      */
     @JsonCreator
     public JsonAdaptedGrade(@JsonProperty("status") String status,
@@ -35,7 +35,7 @@ public class JsonAdaptedGrade {
     }
 
     /**
-     * Converts a given {@code Assignment} into this class for Jackson use.
+     * Converts a given {@code ID} and {@code Grade} into this class for Jackson use.
      */
     public JsonAdaptedGrade(int id, Grade source) {
         this.id = id;
@@ -44,9 +44,9 @@ public class JsonAdaptedGrade {
     }
 
     /**
-     * Converts this {@code JsonAdaptedAssignment} object into the model's {@code Assignment} object.
+     * Converts this {@code JsonAdaptedGrade} object into the model's {@code ID} and {@code Grade} object.
      *
-     * @throws IllegalValueException if there were any data constraints violated in the adapted assignment.
+     * @throws IllegalValueException if there were any data constraints violated in the adapted Grade.
      */
     public Map.Entry<Integer, Grade> toModelType() throws IllegalValueException {
         if (id == null) {

--- a/src/main/java/seedu/edrecord/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/edrecord/storage/JsonAdaptedPerson.java
@@ -31,6 +31,7 @@ class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
     public static final String INVALID_ASSIGNMENT = "Assignment does not exist.";
+    public static final String GRADE_SCORE_MORE_THAN_ASSIGNMENT = "Grade score is more than assignment max score.";
 
     private final String name;
     private final String phone;
@@ -176,10 +177,13 @@ class JsonAdaptedPerson {
             for (JsonAdaptedGrade grade : grades) {
                 Map.Entry<Integer, Grade> pair = grade.toModelType();
                 int id = pair.getKey();
-                Assignment assignment = mod.getAssignmentList().stream()
-                        .filter(asg -> asg.getId() == id)
-                        .findFirst()
+                Grade modelGrade = pair.getValue();
+                Assignment assignment = mod.getAssignment(id)
                         .orElseThrow(() -> new IllegalValueException(INVALID_ASSIGNMENT));
+                if (modelGrade.getScore().isPresent()
+                        && modelGrade.getScore().get().compareTo(assignment.getMaxScore()) > 0) {
+                    throw new IllegalValueException(GRADE_SCORE_MORE_THAN_ASSIGNMENT);
+                }
                 modelGrades.add(assignment, pair.getValue());
             }
         }

--- a/src/main/java/seedu/edrecord/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/edrecord/storage/JsonAdaptedPerson.java
@@ -3,6 +3,7 @@ package seedu.edrecord.storage;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -10,6 +11,8 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.edrecord.commons.exceptions.IllegalValueException;
+import seedu.edrecord.model.assignment.Assignment;
+import seedu.edrecord.model.assignment.Grade;
 import seedu.edrecord.model.group.Group;
 import seedu.edrecord.model.module.Module;
 import seedu.edrecord.model.module.ModuleSet;
@@ -27,6 +30,7 @@ import seedu.edrecord.model.tag.Tag;
 class JsonAdaptedPerson {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Person's %s field is missing!";
+    public static final String INVALID_ASSIGNMENT = "Assignment does not exist.";
 
     private final String name;
     private final String phone;
@@ -34,6 +38,7 @@ class JsonAdaptedPerson {
     private final String info;
     private final String mods;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final List<JsonAdaptedGrade> grades = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -42,7 +47,8 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
                              @JsonProperty("email") String email, @JsonProperty("address") String info,
                              @JsonProperty("modules") String mods,
-                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+                             @JsonProperty("grades") List<JsonAdaptedGrade> grades) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -50,6 +56,9 @@ class JsonAdaptedPerson {
         this.mods = mods;
         if (tagged != null) {
             this.tagged.addAll(tagged);
+        }
+        if (grades != null) {
+            this.grades.addAll(grades);
         }
     }
 
@@ -65,6 +74,12 @@ class JsonAdaptedPerson {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        AssignmentGradeMap grades = source.getGrades();
+        grades.getGrades().keySet().forEach(asg -> {
+            int id = asg.getId();
+            Grade grade = grades.findGrade(asg);
+            this.grades.add(new JsonAdaptedGrade(id, grade));
+        });
     }
 
     /**
@@ -154,9 +169,22 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        // TODO change `new AssignmentGradeMap()` to save grades
-        return new Person(modelName, modelPhone, modelEmail, modelInfo, moduleSet, modelTags,
-                new AssignmentGradeMap());
+        final AssignmentGradeMap modelGrades = new AssignmentGradeMap();
+
+        if (!grades.isEmpty()) {
+            Module mod = moduleSet.getModules().stream().findFirst().get();
+            for (JsonAdaptedGrade grade : grades) {
+                Map.Entry<Integer, Grade> pair = grade.toModelType();
+                int id = pair.getKey();
+                Assignment assignment = mod.getAssignmentList().stream()
+                        .filter(asg -> asg.getId() == id)
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalValueException(INVALID_ASSIGNMENT));
+                modelGrades.add(assignment, pair.getValue());
+            }
+        }
+
+        return new Person(modelName, modelPhone, modelEmail, modelInfo, moduleSet, modelTags, modelGrades);
     }
 
 }

--- a/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
+++ b/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
@@ -88,7 +88,7 @@ class JsonAdaptedModule {
 
         Module module = new Module(code, groupSystem);
 
-        if (assignmentCounter == null) {
+        if (assignmentCounter == null || assignmentCounter <= 0) {
             throw new IllegalValueException(INVALID_COUNTER);
         } else {
             module.setAssignmentCounter(assignmentCounter);
@@ -96,7 +96,7 @@ class JsonAdaptedModule {
 
         for (JsonAdaptedAssignment jsonAdaptedAssignment : assignments) {
             Assignment asg = jsonAdaptedAssignment.toModelType();
-            if (module.hasSameNameAssignment(asg)) {
+            if (module.hasSameNameAssignment(asg) || module.hasSameIdAssignment(asg)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_ASSIGNMENT);
             } else if (asg.getId() < 1 || asg.getId() > assignmentCounter) {
                 throw new IllegalValueException(INVALID_ID);

--- a/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
+++ b/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
@@ -99,7 +99,6 @@ class JsonAdaptedModule {
             if (module.hasSameNameAssignment(asg)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_ASSIGNMENT);
             } else if (asg.getId() < 1 || asg.getId() > assignmentCounter) {
-                System.out.printf("asg id: %s, counter: %s", asg.getId(), assignmentCounter);
                 throw new IllegalValueException(INVALID_ID);
             }
             module.addAssignment(asg);

--- a/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
+++ b/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
@@ -22,10 +22,13 @@ class JsonAdaptedModule {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "Module's %s field is missing!";
     public static final String MESSAGE_DUPLICATE_ASSIGNMENT = "Assignment list for this module contains duplicates.";
+    public static final String INVALID_COUNTER = "Assignment counter for this module is invalid.";
+    public static final String INVALID_ID = "ID for this assignment is invalid.";
 
     private final String code;
     private final List<JsonAdaptedGroup> groups = new ArrayList<>();
     private final List<JsonAdaptedAssignment> assignments = new ArrayList<>();
+    private final Integer assignmentCounter;
 
     /**
      * Constructs a {@code JsonAdaptedModule} with the given module code, groups and assignments.
@@ -33,7 +36,8 @@ class JsonAdaptedModule {
     @JsonCreator
     public JsonAdaptedModule(@JsonProperty("code") String code,
                              @JsonProperty("groups") List<JsonAdaptedGroup> groups,
-                             @JsonProperty("assignments") List<JsonAdaptedAssignment> assignments) {
+                             @JsonProperty("assignments") List<JsonAdaptedAssignment> assignments,
+                             @JsonProperty("id") Integer assignmentCounter) {
         this.code = code;
         if (groups != null) {
             this.groups.addAll(groups);
@@ -41,6 +45,7 @@ class JsonAdaptedModule {
         if (assignments != null) {
             this.assignments.addAll(assignments);
         }
+        this.assignmentCounter = assignmentCounter;
     }
 
     /**
@@ -54,7 +59,7 @@ class JsonAdaptedModule {
         assignments.addAll(source.getAssignmentList().stream()
                 .map(JsonAdaptedAssignment::new)
                 .collect(Collectors.toList()));
-
+        assignmentCounter = source.getAssignmentCounter();
     }
 
     /**
@@ -82,10 +87,20 @@ class JsonAdaptedModule {
         }
 
         Module module = new Module(code, groupSystem);
+
+        if (assignmentCounter == null) {
+            throw new IllegalValueException(INVALID_COUNTER);
+        } else {
+            module.setAssignmentCounter(assignmentCounter);
+        }
+
         for (JsonAdaptedAssignment jsonAdaptedAssignment : assignments) {
             Assignment asg = jsonAdaptedAssignment.toModelType();
             if (module.hasAssignment(asg)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_ASSIGNMENT);
+            } else if (asg.getId() < 1 || asg.getId() > assignmentCounter) {
+                System.out.printf("asg id: %s, counter: %s", asg.getId(), assignmentCounter);
+                throw new IllegalValueException(INVALID_ID);
             }
             module.addAssignment(asg);
         }

--- a/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
+++ b/src/main/java/seedu/edrecord/storage/module/JsonAdaptedModule.java
@@ -96,7 +96,7 @@ class JsonAdaptedModule {
 
         for (JsonAdaptedAssignment jsonAdaptedAssignment : assignments) {
             Assignment asg = jsonAdaptedAssignment.toModelType();
-            if (module.hasAssignment(asg)) {
+            if (module.hasSameNameAssignment(asg)) {
                 throw new IllegalValueException(MESSAGE_DUPLICATE_ASSIGNMENT);
             } else if (asg.getId() < 1 || asg.getId() > assignmentCounter) {
                 System.out.printf("asg id: %s, counter: %s", asg.getId(), assignmentCounter);

--- a/src/main/java/seedu/edrecord/ui/AssignmentListCard.java
+++ b/src/main/java/seedu/edrecord/ui/AssignmentListCard.java
@@ -38,6 +38,7 @@ public class AssignmentListCard extends UiPart<Region> {
     private static final int TABLE_HEADER_SIZE = 3; // in number of normal rows
 
     private static final double WIDTH_PADDING = 0.02;
+    private static final double WIDTH_ID_COL = 0.05;
     private static final double WIDTH_STATUS_COL = 0.2;
     private static final double WIDTH_NAME_COL = 0.4;
     private static final double WIDTH_WEIGHTAGE_COL = 0.2;
@@ -84,6 +85,12 @@ public class AssignmentListCard extends UiPart<Region> {
             }
         }
 
+        TableColumn<Map.Entry<Assignment, Grade>, String> idCol = new TableColumn<>("ID");
+        idCol.setCellValueFactory(c -> {
+            Assignment a = c.getValue().getKey();
+            return new SimpleStringProperty(a.getId().toString());
+        });
+
         TableColumn<Map.Entry<Assignment, Grade>, String> statusCol = new TableColumn<>("Status");
         statusCol.setCellValueFactory(c -> {
             Grade g = map.get(c.getValue().getKey());
@@ -114,8 +121,8 @@ public class AssignmentListCard extends UiPart<Region> {
         assignmentsTable.setItems(items);
 
         List<TableColumn<Map.Entry<Assignment, Grade>, String>> cols =
-                List.of(statusCol, nameCol, weightageCol, scoreCol);
-        double[] weights = {WIDTH_STATUS_COL, WIDTH_NAME_COL, WIDTH_WEIGHTAGE_COL, WIDTH_SCORE_COL};
+                List.of(idCol, statusCol, nameCol, weightageCol, scoreCol);
+        double[] weights = {WIDTH_ID_COL, WIDTH_STATUS_COL, WIDTH_NAME_COL, WIDTH_WEIGHTAGE_COL, WIDTH_SCORE_COL};
         assignmentsTable.getColumns().setAll(cols);
 
         int i = 0;

--- a/src/main/java/seedu/edrecord/ui/AssignmentListCard.java
+++ b/src/main/java/seedu/edrecord/ui/AssignmentListCard.java
@@ -41,9 +41,9 @@ public class AssignmentListCard extends UiPart<Region> {
     private static final double WIDTH_ID_COL = 0.05;
     private static final double WIDTH_STATUS_COL = 0.2;
     private static final double WIDTH_NAME_COL = 0.4;
-    private static final double WIDTH_WEIGHTAGE_COL = 0.2;
+    private static final double WIDTH_WEIGHTAGE_COL = 0.15;
     private static final double WIDTH_SCORE_COL =
-            1 - WIDTH_STATUS_COL - WIDTH_NAME_COL - WIDTH_WEIGHTAGE_COL - WIDTH_PADDING;
+            1 - WIDTH_ID_COL - WIDTH_STATUS_COL - WIDTH_NAME_COL - WIDTH_WEIGHTAGE_COL - WIDTH_PADDING;
 
     /**
      * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.

--- a/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
@@ -269,6 +269,16 @@ public class AddCommandTest {
         public void setAssignment(Assignment target, Assignment editedAssignment) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public int getAssignmentCounter() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAssignmentCounter(int i) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -240,6 +241,11 @@ public class AddCommandTest {
 
         @Override
         public List<Assignment> getAssignmentList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Optional<Assignment> getAssignment(int id) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
@@ -231,7 +231,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public boolean hasAssignmentInCurrentModule(Assignment assignment) {
+        public boolean hasSameNameInCurrentModule(Assignment assignment) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/AddCommandTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -28,7 +27,6 @@ import seedu.edrecord.model.assignment.Assignment;
 import seedu.edrecord.model.module.Module;
 import seedu.edrecord.model.module.ModuleSet;
 import seedu.edrecord.model.module.ReadOnlyModuleSystem;
-import seedu.edrecord.model.name.Name;
 import seedu.edrecord.model.person.PartOfModulePredicate;
 import seedu.edrecord.model.person.Person;
 import seedu.edrecord.testutil.PersonBuilder;
@@ -242,11 +240,6 @@ public class AddCommandTest {
 
         @Override
         public List<Assignment> getAssignmentList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Optional<Assignment> searchAssignment(Name name) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -27,7 +26,6 @@ import seedu.edrecord.model.assignment.Assignment;
 import seedu.edrecord.model.module.Module;
 import seedu.edrecord.model.module.ModuleSet;
 import seedu.edrecord.model.module.ReadOnlyModuleSystem;
-import seedu.edrecord.model.name.Name;
 import seedu.edrecord.model.person.PartOfModulePredicate;
 import seedu.edrecord.model.person.Person;
 import seedu.edrecord.testutil.AssignmentBuilder;
@@ -267,11 +265,6 @@ public class MakeAssignmentCommandTest {
 
         @Override
         public List<Assignment> getAssignmentList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Optional<Assignment> searchAssignment(Name name) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
@@ -256,7 +256,7 @@ public class MakeAssignmentCommandTest {
         }
 
         @Override
-        public boolean hasAssignmentInCurrentModule(Assignment assignment) {
+        public boolean hasSameNameInCurrentModule(Assignment assignment) {
             throw new AssertionError("This method should not be called.");
         }
 
@@ -332,7 +332,7 @@ public class MakeAssignmentCommandTest {
         }
 
         @Override
-        public boolean hasAssignmentInCurrentModule(Assignment assignment) {
+        public boolean hasSameNameInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
             return this.assignment.isSameName(assignment);
         }
@@ -350,7 +350,7 @@ public class MakeAssignmentCommandTest {
         }
 
         @Override
-        public boolean hasAssignmentInCurrentModule(Assignment assignment) {
+        public boolean hasSameNameInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
             return assignmentsAdded.stream().anyMatch(assignment::isSameName);
         }

--- a/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
@@ -269,6 +270,11 @@ public class MakeAssignmentCommandTest {
         }
 
         @Override
+        public Optional<Assignment> getAssignment(int id) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public boolean hasHigherGradeInCurrentModule(Assignment current, Assignment editedAssignment) {
             throw new AssertionError("This method should not be called.");
         }
@@ -327,7 +333,7 @@ public class MakeAssignmentCommandTest {
         @Override
         public boolean hasSameNameInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
-            return this.assignment.isSameName(assignment);
+            return this.assignment.isSameAssignment(assignment);
         }
     }
 
@@ -345,7 +351,7 @@ public class MakeAssignmentCommandTest {
         @Override
         public boolean hasSameNameInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
-            return assignmentsAdded.stream().anyMatch(assignment::isSameName);
+            return assignmentsAdded.stream().anyMatch(assignment::isSameAssignment);
         }
 
         @Override

--- a/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
+++ b/src/test/java/seedu/edrecord/logic/commands/MakeAssignmentCommandTest.java
@@ -36,13 +36,14 @@ import seedu.edrecord.ui.PersonListPanel;
 public class MakeAssignmentCommandTest {
     @Test
     public void constructor_nullAssignment_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new MakeAssignmentCommand(null));
+        assertThrows(NullPointerException.class, () -> new MakeAssignmentCommand(null, null, null));
     }
 
     @Test
     public void execute_nullModel_throwsNullPointerException() {
         Assignment validAssignment = new AssignmentBuilder().build();
-        assertThrows(NullPointerException.class, () -> new MakeAssignmentCommand(validAssignment).execute(null));
+        assertThrows(NullPointerException.class, () -> new MakeAssignmentCommand(validAssignment.getName(),
+                validAssignment.getWeightage(), validAssignment.getMaxScore()).execute(null));
     }
 
 
@@ -50,7 +51,8 @@ public class MakeAssignmentCommandTest {
     public void execute_noModuleSelected_throwsCommandException() {
         Assignment validAssignment = new AssignmentBuilder().build();
         ModelStubWithoutSelectedModule modelStub = new ModelStubWithoutSelectedModule();
-        MakeAssignmentCommand addAssignmentCommand = new MakeAssignmentCommand(validAssignment);
+        MakeAssignmentCommand addAssignmentCommand = new MakeAssignmentCommand(validAssignment.getName(),
+                validAssignment.getWeightage(), validAssignment.getMaxScore());
 
         assertThrows(CommandException.class,
                 MESSAGE_NO_MODULE_SELECTED, () -> addAssignmentCommand.execute(modelStub));
@@ -60,7 +62,8 @@ public class MakeAssignmentCommandTest {
     public void execute_duplicateAssignment_throwsCommandException() {
         Assignment validAssignment = new AssignmentBuilder().build();
         ModelStub modelStub = new ModelStubWithAssignment(validAssignment);
-        MakeAssignmentCommand addAssignmentCommand = new MakeAssignmentCommand(validAssignment);
+        MakeAssignmentCommand addAssignmentCommand = new MakeAssignmentCommand(validAssignment.getName(),
+                validAssignment.getWeightage(), validAssignment.getMaxScore());
 
         assertThrows(CommandException.class,
                 MakeAssignmentCommand.MESSAGE_DUPLICATE_ASSIGNMENT, () -> addAssignmentCommand.execute(modelStub));
@@ -71,7 +74,8 @@ public class MakeAssignmentCommandTest {
         ModelStubAcceptingAssignmentAdded modelStub = new ModelStubAcceptingAssignmentAdded();
         Assignment validAssignment = new AssignmentBuilder().build();
 
-        CommandResult commandResult = new MakeAssignmentCommand(validAssignment).execute(modelStub);
+        CommandResult commandResult = new MakeAssignmentCommand(validAssignment.getName(),
+                validAssignment.getWeightage(), validAssignment.getMaxScore()).execute(modelStub);
 
         assertEquals(
                 String.format(MakeAssignmentCommand.MESSAGE_SUCCESS, validAssignment),
@@ -81,16 +85,19 @@ public class MakeAssignmentCommandTest {
 
     @Test
     public void equals() {
-        Assignment mission = new AssignmentBuilder().withName("Mission").build();
-        Assignment training = new AssignmentBuilder().withName("Training").build();
-        MakeAssignmentCommand addMission = new MakeAssignmentCommand(mission);
-        MakeAssignmentCommand addTraining = new MakeAssignmentCommand(training);
+        Assignment mission = new AssignmentBuilder().withName("Mission").withId(0).build();
+        Assignment training = new AssignmentBuilder().withName("Training").withId(1).build();
+        MakeAssignmentCommand addMission = new MakeAssignmentCommand(mission.getName(),
+                mission.getWeightage(), mission.getMaxScore());
+        MakeAssignmentCommand addTraining = new MakeAssignmentCommand(training.getName(),
+                mission.getWeightage(), mission.getMaxScore());
 
         // same object -> returns true
         assertTrue(addMission.equals(addMission));
 
         // same values -> returns true
-        MakeAssignmentCommand addMissionCopy = new MakeAssignmentCommand(mission);
+        MakeAssignmentCommand addMissionCopy = new MakeAssignmentCommand(mission.getName(),
+                mission.getWeightage(), mission.getMaxScore());
         assertTrue(addMission.equals(addMissionCopy));
 
         // different types -> returns false
@@ -287,6 +294,15 @@ public class MakeAssignmentCommandTest {
         public void setAssignment(Assignment target, Assignment editedAssignment) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public int getAssignmentCounter() {
+            return 0;
+        }
+
+        @Override
+        public void setAssignmentCounter(int i) {
+        }
     }
 
     /**
@@ -318,7 +334,7 @@ public class MakeAssignmentCommandTest {
         @Override
         public boolean hasAssignmentInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
-            return this.assignment.isSameAssignment(assignment);
+            return this.assignment.isSameName(assignment);
         }
     }
 
@@ -336,7 +352,7 @@ public class MakeAssignmentCommandTest {
         @Override
         public boolean hasAssignmentInCurrentModule(Assignment assignment) {
             requireNonNull(assignment);
-            return assignmentsAdded.stream().anyMatch(assignment::isSameAssignment);
+            return assignmentsAdded.stream().anyMatch(assignment::isSameName);
         }
 
         @Override

--- a/src/test/java/seedu/edrecord/model/name/NameTest.java
+++ b/src/test/java/seedu/edrecord/model/name/NameTest.java
@@ -37,4 +37,16 @@ public class NameTest {
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
         assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
     }
+
+    @Test
+    public void equalsIgnoreCase() {
+        Name lowerCase = new Name("abcd");
+        Name upperCase = new Name("ABCD");
+        Name mixedCase = new Name("aBcD");
+        Name other = new Name("abce");
+
+        assertTrue(lowerCase.equalsIgnoreCase(upperCase));
+        assertTrue(lowerCase.equalsIgnoreCase(mixedCase));
+        assertFalse(lowerCase.equalsIgnoreCase(other));
+    }
 }

--- a/src/test/java/seedu/edrecord/storage/JsonAdaptedAssignmentTest.java
+++ b/src/test/java/seedu/edrecord/storage/JsonAdaptedAssignmentTest.java
@@ -26,7 +26,7 @@ public class JsonAdaptedAssignmentTest {
     @Test
     public void toModelType_validAssignmentDetails_returnsAssignment() throws Exception {
         JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(MIDTERM);
-        assertEquals(MIDTERM.isSameName(assignment.toModelType()), true);
+        assertEquals(MIDTERM.isSameAssignment(assignment.toModelType()), true);
     }
 
     @Test

--- a/src/test/java/seedu/edrecord/storage/JsonAdaptedAssignmentTest.java
+++ b/src/test/java/seedu/edrecord/storage/JsonAdaptedAssignmentTest.java
@@ -21,51 +21,58 @@ public class JsonAdaptedAssignmentTest {
     private static final String VALID_NAME = MIDTERM.getName().name;
     private static final String VALID_WEIGHTAGE = String.valueOf(MIDTERM.getWeightage().weightage);
     private static final String VALID_MAX_SCORE = String.valueOf(MIDTERM.getMaxScore().score);
+    private static final int VALID_ID = MIDTERM.getId();
 
     @Test
     public void toModelType_validAssignmentDetails_returnsAssignment() throws Exception {
         JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(MIDTERM);
-        assertEquals(MIDTERM, assignment.toModelType());
+        assertEquals(MIDTERM.isSameName(assignment.toModelType()), true);
     }
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(INVALID_NAME, VALID_WEIGHTAGE, VALID_MAX_SCORE);
+        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(INVALID_NAME, VALID_WEIGHTAGE,
+                VALID_MAX_SCORE, VALID_ID);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(null, VALID_WEIGHTAGE, VALID_MAX_SCORE);
+        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(null, VALID_WEIGHTAGE,
+                VALID_MAX_SCORE, VALID_ID);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
 
     @Test
     public void toModelType_invalidWeightage_throwsIllegalValueException() {
-        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, INVALID_WEIGHTAGE, VALID_MAX_SCORE);
+        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, INVALID_WEIGHTAGE,
+                VALID_MAX_SCORE, VALID_ID);
         String expectedMessage = Weightage.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
 
     @Test
     public void toModelType_nullWeightage_throwsIllegalValueException() {
-        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, null, VALID_MAX_SCORE);
+        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, null,
+                VALID_MAX_SCORE, VALID_ID);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Weightage.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
 
     @Test
     public void toModelType_invalidMaxScore_throwsIllegalValueException() {
-        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, VALID_WEIGHTAGE, INVALID_MAX_SCORE);
+        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, VALID_WEIGHTAGE,
+                INVALID_MAX_SCORE, VALID_ID);
         String expectedMessage = Score.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }
 
     @Test
     public void toModelType_nullMaxScore_throwsIllegalValueException() {
-        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, VALID_WEIGHTAGE, null);
+        JsonAdaptedAssignment assignment = new JsonAdaptedAssignment(VALID_NAME, VALID_WEIGHTAGE,
+                null, VALID_ID);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Score.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, assignment::toModelType);
     }

--- a/src/test/java/seedu/edrecord/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/edrecord/storage/JsonAdaptedPersonTest.java
@@ -38,6 +38,7 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedGrade> VALID_GRADES = new ArrayList<>();
 
     //TODO: Add assignments to a person's modules in json format, so that this tests can pass.
     /*
@@ -55,7 +56,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "]" , VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "]" , VALID_TAGS, VALID_GRADES);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -63,7 +64,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,7 +72,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -79,7 +80,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -87,7 +88,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -95,7 +96,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,7 +104,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidInfo_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = Info.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -111,7 +112,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullInfo_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Info.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -119,7 +120,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidModule_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_INFO,
-                        INVALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS);
+                        INVALID_MODULE + ":[" + VALID_GROUP + "," + VALID_GROUP2 + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = ModuleSet.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -127,7 +128,7 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullOtherModuleSet_throwsIllegalValueException() {
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_INFO, null,
-                VALID_TAGS);
+                VALID_TAGS, VALID_GRADES);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, ModuleSet.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -136,7 +137,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidGroupFormat_throwsIllegalValueException() {
         setTypicalModuleSystem();
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":" + VALID_GROUP , VALID_TAGS);
+                VALID_MODULE + ":" + VALID_GROUP , VALID_TAGS, VALID_GRADES);
         String expectedMessage = ModuleSet.MESSAGE_GROUP_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -144,7 +145,7 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidGroup_throwsIllegalValueException() {
         setTypicalModuleSystem();
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + INVALID_GROUP + "]", VALID_TAGS);
+                VALID_MODULE + ":[" + INVALID_GROUP + "]", VALID_TAGS, VALID_GRADES);
         String expectedMessage = Group.MESSAGE_DOES_NOT_EXIST;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -154,7 +155,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_INFO,
-                VALID_MODULE + ":[" + VALID_GROUP + "]", invalidTags);
+                VALID_MODULE + ":[" + VALID_GROUP + "]", invalidTags, VALID_GRADES);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/edrecord/testutil/AssignmentBuilder.java
+++ b/src/test/java/seedu/edrecord/testutil/AssignmentBuilder.java
@@ -13,10 +13,12 @@ public class AssignmentBuilder {
     public static final String DEFAULT_NAME = "Assignment 1";
     public static final String DEFAULT_WEIGHTAGE = "2.5";
     public static final String DEFAULT_MAX_SCORE = "20";
+    public static final int DEFAULT_ID = 0;
 
     private Name name;
     private Weightage weightage;
     private Score score;
+    private int id;
 
     /**
      * Creates an {@code AssignmentBuilder} with the default details.
@@ -25,6 +27,7 @@ public class AssignmentBuilder {
         name = new Name(DEFAULT_NAME);
         weightage = new Weightage(DEFAULT_WEIGHTAGE);
         score = new Score(DEFAULT_MAX_SCORE);
+        id = DEFAULT_ID;
     }
 
     /**
@@ -34,6 +37,7 @@ public class AssignmentBuilder {
         name = toCopy.getName();
         weightage = toCopy.getWeightage();
         score = toCopy.getMaxScore();
+        id = toCopy.getId();
     }
 
     /**
@@ -61,9 +65,17 @@ public class AssignmentBuilder {
     }
 
     /**
+     * Sets the {@code ID} of the {@code Assignment} that we are building.
+     */
+    public AssignmentBuilder withId(int id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
      * Builds and returns the Assignment.
      */
     public Assignment build() {
-        return new Assignment(name, weightage, score);
+        return new Assignment(name, weightage, score, id);
     }
 }

--- a/src/test/java/seedu/edrecord/testutil/ModuleBuilder.java
+++ b/src/test/java/seedu/edrecord/testutil/ModuleBuilder.java
@@ -31,6 +31,14 @@ public class ModuleBuilder {
     }
 
 
+    /**
+     * Sets the {@code assignmentCounter} of the {@code Module} that we are building.
+     */
+    public ModuleBuilder withCounter(int i) {
+        module.setAssignmentCounter(i);
+        return this;
+    }
+
     public Module build() {
         return module;
     }

--- a/src/test/java/seedu/edrecord/testutil/TypicalAssignments.java
+++ b/src/test/java/seedu/edrecord/testutil/TypicalAssignments.java
@@ -5,21 +5,22 @@ import seedu.edrecord.model.assignment.Assignment;
 public class TypicalAssignments {
 
     public static final Assignment IP = new AssignmentBuilder()
-            .withName("iP").withWeightage("15").withMaxScore("15").build();
+            .withName("iP").withWeightage("15").withMaxScore("15").withId(1).build();
     public static final Assignment TP = new AssignmentBuilder()
-            .withName("tP").withWeightage("50").withMaxScore("50").build();
+            .withName("tP").withWeightage("50").withMaxScore("50").withId(2).build();
     public static final Assignment TUTORIAL = new AssignmentBuilder()
-            .withName("tutorial").withWeightage("0.25").withMaxScore("10").build();
+            .withName("tutorial").withWeightage("0.25").withMaxScore("10").withId(3).build();
     public static final Assignment LAB = new AssignmentBuilder()
-            .withName("lab").withWeightage("2.5").withMaxScore("10").build();
+            .withName("lab").withWeightage("2.5").withMaxScore("10").withId(4).build();
     public static final Assignment QUIZ = new AssignmentBuilder()
-            .withName("quiz").withWeightage("1.25").withMaxScore("15").build();
+            .withName("quiz").withWeightage("1.25").withMaxScore("15").withId(5).build();
     public static final Assignment PE = new AssignmentBuilder()
-            .withName("practical exam").withWeightage("15").withMaxScore("25").build();
+            .withName("practical exam").withWeightage("15").withMaxScore("25").withId(6).build();
     public static final Assignment MIDTERM = new AssignmentBuilder()
-            .withName("midterm").withWeightage("15").withMaxScore("55").build();
+            .withName("midterm").withWeightage("15").withMaxScore("55").withId(7).build();
     public static final Assignment FINAL = new AssignmentBuilder()
-            .withName("final").withWeightage("40").withMaxScore("100").build();
+            .withName("final").withWeightage("40").withMaxScore("100").withId(8).build();
+
 
     private TypicalAssignments() {} // prevents instantiation
 

--- a/src/test/java/seedu/edrecord/testutil/TypicalModules.java
+++ b/src/test/java/seedu/edrecord/testutil/TypicalModules.java
@@ -23,17 +23,17 @@ import seedu.edrecord.model.module.ModuleSystem;
 public class TypicalModules {
 
     public static final Module CS2103 = new ModuleBuilder("CS2103")
-            .withAssignment(IP).withAssignment(TP)
+            .withAssignment(IP).withAssignment(TP).withCounter(9)
             .withGroup(T03).withGroup(T07).build();
     public static final Module CS2103T = new ModuleBuilder("CS2103T")
-            .withAssignment(PE)
+            .withAssignment(PE).withCounter(9)
             .withGroup(T03).withGroup(T07).build();
     public static final Module CS3230 = new ModuleBuilder("CS3230")
             .withGroup(T03).withGroup(T07).build();
     public static final Module CS2100 = new ModuleBuilder("CS2100")
-            .withAssignment(QUIZ).withAssignment(MIDTERM).withAssignment(FINAL).build();
+            .withAssignment(QUIZ).withAssignment(MIDTERM).withAssignment(FINAL).withCounter(9).build();
     public static final Module CS2102 = new ModuleBuilder("CS2102")
-            .withAssignment(TUTORIAL).build();
+            .withAssignment(TUTORIAL).withCounter(9).build();
 
     // withGroups()
     // public static final Module CS2103 = new Module("CS2103", getTypicalGroupSystem());


### PR DESCRIPTION
- Add ID field to assignments. This ID field is unique within a module. Closes #194
- Update `edasg`, `dlasg`, `grade`, `dlgrade` to use assignment ID. Removed searching for assignment by name. Closes #186
- Assignment view in GUI now shows assignment ID column. Closes #141 
- Grades are now saving correctly to the JSON file. Closes #122 