### PR TITLE
Fix assignment bugs

### DIFF
--- a/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
@@ -24,10 +24,10 @@ public class DeleteAssignmentCommand extends Command {
 
     public static final String MESSAGE_DELETE_ASSIGNMENT_SUCCESS = "Deleted assignment: %1$s";
 
-    private final Index index;
+    private final Index id;
 
-    public DeleteAssignmentCommand(Index index) {
-        this.index = index;
+    public DeleteAssignmentCommand(Index id) {
+        this.id = id;
     }
 
     @Override
@@ -37,15 +37,12 @@ public class DeleteAssignmentCommand extends Command {
         if (!model.hasSelectedModule()) {
             throw new CommandException(Messages.MESSAGE_NO_MODULE_SELECTED);
         }
-        List<Assignment> assignmentList = model.getAssignmentList();
 
-        if (index.getOneBased() >= model.getAssignmentCounter()) {
+        if (id.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment asgToDelete = assignmentList.stream()
-                .filter(asg -> asg.getId() == index.getOneBased())
-                .findFirst()
+        Assignment asgToDelete = model.getAssignment(id.getOneBased())
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
         model.deleteAssignment(asgToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_ASSIGNMENT_SUCCESS, asgToDelete));
@@ -55,6 +52,6 @@ public class DeleteAssignmentCommand extends Command {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof DeleteAssignmentCommand // instanceof handles nulls
-                && index.equals(((DeleteAssignmentCommand) other).index)); // state check
+                && id.equals(((DeleteAssignmentCommand) other).id)); // state check
     }
 }

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
@@ -2,8 +2,6 @@ package seedu.edrecord.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import java.util.List;
-
 import seedu.edrecord.commons.core.Messages;
 import seedu.edrecord.commons.core.index.Index;
 import seedu.edrecord.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/DeleteAssignmentCommand.java
@@ -18,8 +18,8 @@ public class DeleteAssignmentCommand extends Command {
     public static final String COMMAND_WORD = "dlasg";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes an assignment using its index number used in the displayed assignment list.\n"
-            + "Parameters: INDEX (must be a positive integer)\n"
+            + ": Deletes an assignment using its ID number used in the displayed assignment list.\n"
+            + "Parameters: ID (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_ASSIGNMENT_SUCCESS = "Deleted assignment: %1$s";

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -27,14 +27,14 @@ public class EditAssignmentCommand extends Command {
     public static final String COMMAND_WORD = "edasg";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the assignment using "
-            + "its index number as shown in the displayed assignment list. "
+            + "its ID number as shown in the displayed assignment list. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) "
+            + "Parameters: ID (must be a positive integer) "
             + "[" + PREFIX_NAME + "NAME] "
             + "[" + PREFIX_WEIGHTAGE + "WEIGHTAGE] "
             + "[" + PREFIX_SCORE + "MAX_SCORE]\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_NAME + "Side Quest 7 "
+            + PREFIX_NAME + "Midterm "
             + PREFIX_WEIGHTAGE + "2.5";
 
     public static final String MESSAGE_EDIT_ASSIGNMENT_SUCCESS = "Edited Assignment: %1$s";

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -45,18 +45,18 @@ public class EditAssignmentCommand extends Command {
     public static final String MESSAGE_TOTAL_WEIGHTAGE_EXCEEDS_100 =
             "The edited assignment brings the total module weightage above 100%";
 
-    private final Index index;
+    private final Index id;
     private final EditAssignmentDescriptor editDescriptor;
 
     /**
-     * @param index The index of the assignment in the assignment list to edit
+     * @param id The index of the assignment in the assignment list to edit
      * @param editDescriptor Details to edit the assignment with
      */
-    public EditAssignmentCommand(Index index, EditAssignmentDescriptor editDescriptor) {
-        requireNonNull(index);
+    public EditAssignmentCommand(Index id, EditAssignmentDescriptor editDescriptor) {
+        requireNonNull(id);
         requireNonNull(editDescriptor);
 
-        this.index = index;
+        this.id = id;
         this.editDescriptor = new EditAssignmentDescriptor(editDescriptor);
     }
 
@@ -66,20 +66,18 @@ public class EditAssignmentCommand extends Command {
         if (!model.hasSelectedModule()) {
             throw new CommandException(MESSAGE_NO_MODULE_SELECTED);
         }
-        List<Assignment> assignmentList = model.getSelectedModule().getValue().getAssignmentList();
 
-        if (index.getOneBased() >= model.getAssignmentCounter()) {
+        if (id.getOneBased() >= model.getAssignmentCounter()) {
             throw new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX);
         }
 
-        Assignment asgToEdit = assignmentList.stream()
-                .filter(asg -> asg.getId() == index.getOneBased())
-                .findFirst()
+        Assignment asgToEdit = model.getAssignment(id.getOneBased())
                 .orElseThrow(() -> new CommandException(Messages.MESSAGE_INVALID_ASSIGNMENT_DISPLAYED_INDEX));
 
         Assignment editedAsg = createEditedAssignment(asgToEdit, editDescriptor);
 
-        if (model.hasSameNameInCurrentModule(editedAsg)) {
+        // if name edited, check if other assignments have the same name
+        if (!(asgToEdit.getName().equals(editedAsg.getName())) && model.hasSameNameInCurrentModule(editedAsg)) {
             throw new CommandException(MESSAGE_DUPLICATE_ASSIGNMENT);
         }
 
@@ -138,7 +136,7 @@ public class EditAssignmentCommand extends Command {
 
         // state check
         EditAssignmentCommand e = (EditAssignmentCommand) other;
-        return index.equals(e.index)
+        return id.equals(e.id)
                 && editDescriptor.equals(e.editDescriptor);
     }
 

--- a/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
+++ b/src/main/java/seedu/edrecord/logic/commands/EditAssignmentCommand.java
@@ -6,7 +6,6 @@ import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_SCORE;
 import static seedu.edrecord.logic.parser.CliSyntax.PREFIX_WEIGHTAGE;
 
-import java.util.List;
 import java.util.Optional;
 
 import seedu.edrecord.commons.core.Messages;

--- a/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
+++ b/src/main/java/seedu/edrecord/model/assignment/UniqueAssignmentList.java
@@ -24,7 +24,7 @@ import seedu.edrecord.model.assignment.exceptions.DuplicateAssignmentException;
  * @see Assignment#isSameAssignment(Assignment)
  */
 public class UniqueAssignmentList implements Iterable<Assignment> {
-    private static final Weightage maximumTotalWeightage = new Weightage("100");
+    private static final float MAXIMUM_TOTAL_WEIGHTAGE = 100f;
 
     private final ObservableList<Assignment> internalList = FXCollections.observableArrayList();
     private final ObservableList<Assignment> internalUnmodifiableList =
@@ -45,8 +45,8 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
      * the total weightage of all assignments in this list to above 100%.
      */
     public boolean isTotalWeightageExceeded(Assignment toAdd) {
-        Weightage addedWeightage = getTotalAddedWeightage(toAdd);
-        return addedWeightage.compareTo(maximumTotalWeightage) > 0;
+        Float addedWeightage = getTotalAddedWeightage(toAdd);
+        return addedWeightage > MAXIMUM_TOTAL_WEIGHTAGE;
     }
 
     /**
@@ -185,13 +185,13 @@ public class UniqueAssignmentList implements Iterable<Assignment> {
      * Returns the total weightage of all assignments in this list, plus
      * the weightage of assignment {@code toAdd}.
      */
-    private Weightage getTotalAddedWeightage(Assignment toAdd) {
+    private Float getTotalAddedWeightage(Assignment toAdd) {
         Float total = 0f;
         for (Assignment assignment : internalList) {
             total += assignment.getWeightage().weightage;
         }
         total += toAdd.getWeightage().weightage;
-        return new Weightage(String.valueOf(total));
+        return total;
     }
 }
 


### PR DESCRIPTION
- When creating a new weightage with value exceeding 100, an `IllegalValueException` is thrown without user feedback. Changed to comparing the value of the weightages directly instead.
- Fixed editing assignments but not changing the name of the assignment.